### PR TITLE
Make `todo!` exception surface as pickable python `NotImplementedError`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,21 @@
+/// Custom `todo!` macro that returns a pickable `PyNotImplementedError` instead of
+/// a non-pickable `PanicException`. This allows Django's test suite to run in parallel.
+///
+/// This macro shadows the standard library's `todo!` macro throughout the crate.
+#[macro_export]
+macro_rules! todo {
+    () => {{
+        let err: ::pyo3::PyErr = ::pyo3::exceptions::PyNotImplementedError::new_err("not yet implemented");
+        return Err(err.into())
+    }};
+    ($($arg:tt)+) => {{
+        let err: ::pyo3::PyErr = ::pyo3::exceptions::PyNotImplementedError::new_err(
+            format!("not yet implemented: {}", format_args!($($arg)+))
+        );
+        return Err(err.into())
+    }};
+}
+
 mod error;
 mod filters;
 mod lex;

--- a/src/loaders.rs
+++ b/src/loaders.rs
@@ -220,7 +220,7 @@ impl ExternalLoader {
         _template_name: &str,
         _engine: &EngineData,
     ) -> Result<PyResult<Template>, LoaderError> {
-        todo!()
+        std::todo!() // Bail here because it does not make much sense to convert from PyErr to empty LoaderError
     }
 }
 


### PR DESCRIPTION
Git hit by that when trying to run django tests with this engine for #92 with `./runtests.py template_tests`

It was causing errors because `pyo3_runtime.PanicException` cannot be pickled

<details>
<summary>
Sample error
</summary>

```
test_middleware_caching (template_tests.test_response.CacheMiddlewareTest.test_middleware_caching) failed:

    PanicException('not yet implemented: now')

Unfortunately, the exception it raised cannot be pickled, making it impossible
for the parallel test runner to handle it cleanly.

Here's the error encountered while trying to pickle the exception:

    PicklingError("Can't pickle <class 'pyo3_runtime.PanicException'>:
    import of module 'pyo3_runtime' failed")

You should re-run this test with the --parallel=1 option to reproduce the
failure and get a correct traceback.

    failures = django_tests(
               ^^^^^^^^^^^^^
  File "/home/thibaut/workspace/django/tests/./runtests.py", line 443, in django_tests
    failures = test_runner.run_tests(test_labels)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thibaut/workspace/django/django/test/runner.py", line 1114, in run_tests
    result = self.run_suite(suite)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/home/thibaut/workspace/django/django/test/runner.py", line 1041, in run_suite
    return runner.run(suite)
           ^^^^^^^^^^^^^^^^^
  File "/home/thibaut/.local/share/uv/python/cpython-3.12.6-linux-x86_64-gnu/lib/python3.12/unittest/runner.py", line 240, in run
    test(result)
  File "/home/thibaut/.local/share/uv/python/cpython-3.12.6-linux-x86_64-gnu/lib/python3.12/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thibaut/workspace/django/django/test/runner.py", line 570, in run
    subsuite_index, events = test_results.next(timeout=0.1)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thibaut/.local/share/uv/python/cpython-3.12.6-linux-x86_64-gnu/lib/python3.12/multiprocessing/pool.py", line 873, in next
    raise value
multiprocessing.pool.MaybeEncodingError: Error sending result: '<multiprocessing.pool.ExceptionWithTraceback object at 0x70bd0ea2cc80>'. Reason: 'PicklingError("Can't pickle <class 'pyo3_runtime.PanicException'>: import of module 'pyo3_runtime' failed")'
Exception ignored in: <function Pool.__del__ at 0x70bd0b3c5440>
Traceback (most recent call last):
  File "/home/thibaut/.local/share/uv/python/cpython-3.12.6-linux-x86_64-gnu/lib/python3.12/multiprocessing/pool.py", line 268, in __del__
ResourceWarning: unclosed running multiprocessing pool <multiprocessing.pool.Pool state=RUN pool_size=32>
```

</details>


I've mostly matched the default `todo!` implementation but raising python's NotImplementedError's