### PR TITLE
Use `PyResult` consistently

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ pub enum PyRenderError {
 }
 
 impl PyRenderError {
-    pub fn try_into_render_error(self) -> Result<RenderError, PyErr> {
+    pub fn try_into_render_error(self) -> PyResult<RenderError> {
         match self {
             Self::RenderError(err) => Ok(err),
             Self::PyErr(err) => Err(err),

--- a/src/loaders.rs
+++ b/src/loaders.rs
@@ -31,7 +31,7 @@ fn safe_join(directory: &Path, template_name: &str) -> Option<PathBuf> {
     }
 }
 
-fn get_app_template_dir(path: Bound<'_, PyAny>, dirname: &str) -> Result<Option<PathBuf>, PyErr> {
+fn get_app_template_dir(path: Bound<'_, PyAny>, dirname: &str) -> PyResult<Option<PathBuf>> {
     if path.is_truthy()? {
         let path_buf: PathBuf = path.extract()?;
         let template_path = path_buf.join(dirname);
@@ -48,7 +48,7 @@ fn get_app_template_dir(path: Bound<'_, PyAny>, dirname: &str) -> Result<Option<
     key = "String",      // Use owned String as key
     convert = r##"{ dirname.to_string() }"## // Convert &str to String
 )]
-fn get_app_template_dirs(py: Python<'_>, dirname: &str) -> Result<Vec<PathBuf>, PyErr> {
+fn get_app_template_dirs(py: Python<'_>, dirname: &str) -> PyResult<Vec<PathBuf>> {
     let apps_module = PyModule::import(py, "django.apps")?;
     let apps = apps_module.getattr("apps")?;
     let app_configs = apps.call_method0("get_app_configs")?;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -812,7 +812,7 @@ pub enum PyParseError {
 }
 
 impl PyParseError {
-    pub fn try_into_parse_error(self) -> Result<ParseError, PyErr> {
+    pub fn try_into_parse_error(self) -> PyResult<ParseError> {
         match self {
             Self::ParseError(err) => Ok(err),
             Self::PyErr(err) => Err(err),
@@ -1359,7 +1359,7 @@ impl<'t, 'l, 'py> Parser<'t, 'l, 'py> {
                 .map(|v| v?.getattr("cell_contents"))
                 .collect::<Result<Vec<_>, _>>()?;
 
-            fn get_defaults_count(defaults: &Bound<'_, PyAny>) -> Result<usize, PyErr> {
+            fn get_defaults_count(defaults: &Bound<'_, PyAny>) -> PyResult<usize> {
                 match defaults.is_none() {
                     true => Ok(0),
                     false => defaults.len(),
@@ -1368,13 +1368,13 @@ impl<'t, 'l, 'py> Parser<'t, 'l, 'py> {
 
             fn get_kwonly_defaults(
                 kwonly_defaults: &Bound<'_, PyAny>,
-            ) -> Result<HashSet<String>, PyErr> {
+            ) -> PyResult<HashSet<String>> {
                 match kwonly_defaults.is_none() {
                     true => Ok(HashSet::new()),
                     false => kwonly_defaults
                         .try_iter()?
                         .map(|item| item?.extract())
-                        .collect::<Result<_, PyErr>>(),
+                        .collect::<PyResult<_>>(),
                 }
             }
 
@@ -1485,14 +1485,14 @@ impl<'t, 'l, 'py> Parser<'t, 'l, 'py> {
     fn get_tags(
         &mut self,
         library: &Bound<'py, PyAny>,
-    ) -> Result<HashMap<String, Bound<'py, PyAny>>, PyErr> {
+    ) -> PyResult<HashMap<String, Bound<'py, PyAny>>> {
         library.getattr(intern!(self.py, "tags"))?.extract()
     }
 
     fn get_filters(
         &mut self,
         library: &Bound<'py, PyAny>,
-    ) -> Result<HashMap<String, Bound<'py, PyAny>>, PyErr> {
+    ) -> PyResult<HashMap<String, Bound<'py, PyAny>>> {
         library.getattr(intern!(self.py, "filters"))?.extract()
     }
 

--- a/src/render/common.rs
+++ b/src/render/common.rs
@@ -17,14 +17,14 @@ use crate::types::Text;
 use crate::types::TranslatedText;
 use crate::types::Variable;
 
-fn has_truthy_attr(variable: &Bound<'_, PyAny>, attr: &Bound<'_, PyString>) -> Result<bool, PyErr> {
+fn has_truthy_attr(variable: &Bound<'_, PyAny>, attr: &Bound<'_, PyString>) -> PyResult<bool> {
     match variable.getattr(attr) {
         Ok(attr) if attr.is_truthy()? => Ok(true),
         _ => Ok(false),
     }
 }
 
-fn resolve_callable(variable: Bound<'_, PyAny>) -> Result<Option<Bound<'_, PyAny>>, PyErr> {
+fn resolve_callable(variable: Bound<'_, PyAny>) -> PyResult<Option<Bound<'_, PyAny>>> {
     if !variable.is_callable() {
         return Ok(Some(variable));
     }

--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -429,7 +429,7 @@ mod tests {
     use pyo3::types::{PyDict, PyString};
     static MARK_SAFE: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 
-    fn mark_safe(py: Python<'_>, string: String) -> Result<Py<PyAny>, PyErr> {
+    fn mark_safe(py: Python<'_>, string: String) -> PyResult<Py<PyAny>> {
         let mark_safe = match MARK_SAFE.get(py) {
             Some(mark_safe) => mark_safe,
             None => {

--- a/src/render/tags.rs
+++ b/src/render/tags.rs
@@ -779,7 +779,7 @@ fn add_context_to_args<'py>(
     py: Python<'py>,
     args: &mut VecDeque<Bound<'py, PyAny>>,
     context: &mut Context,
-) -> Result<Bound<'py, PyAny>, PyErr> {
+) -> PyResult<Bound<'py, PyAny>> {
     // Take ownership of `context` so we can pass it to Python.
     // The `context` variable now points to an empty `Context` instance which will not be
     // used except as a placeholder.

--- a/src/render/types.rs
+++ b/src/render/types.rs
@@ -307,7 +307,7 @@ impl PyContext {
         guard.get(&key).is_some()
     }
 
-    fn __getitem__<'py>(&self, py: Python<'py>, key: String) -> Result<Bound<'py, PyAny>, PyErr> {
+    fn __getitem__<'py>(&self, py: Python<'py>, key: String) -> PyResult<Bound<'py, PyAny>> {
         let guard = self
             .context
             .lock_py_attached(py)


### PR DESCRIPTION
Minor cleanup to have a consistent type accross the codebase for these. This uses the pyo3 alias
```rust
/// Represents the result of a Python call.
pub type PyResult<T> = Result<T, PyErr>;
```