### PR TITLE
Fix pr comment workflow

### DIFF
--- a/.github/workflows/pr-comment-django-test-suite.yml
+++ b/.github/workflows/pr-comment-django-test-suite.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Skip symlinks
         if: steps.download-ecosystem-result.outputs.found_artifact == 'true'
         run: |
-          // Guard against malicious ecosystem results that symlink to a secret
-          // file on this runner
+          # Guard against malicious ecosystem results that symlink to a secret
+          # file on this runner
           if [[ -L test-diff-result ]]
           then
               echo "Error: test-diff-result cannot be a symlink"


### PR DESCRIPTION
Comment should be `#` not `//` in ci or it's misinterpreted as a directory path.

This should fix failures like https://github.com/LilyFirefly/django-rusty-templates/actions/runs/19275459766/job/55114050713 once it's merged