### PR TITLE
Improve error message for broken __bool__ in yesno filter

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -105,11 +105,12 @@ pub struct UpperFilter;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct YesnoFilter {
+    pub at: (usize, usize),
     pub argument: Option<Argument>,
 }
 
 impl YesnoFilter {
-    pub fn new(argument: Option<Argument>) -> Self {
-        Self { argument }
+    pub fn new(at: (usize, usize), argument: Option<Argument>) -> Self {
+        Self { at, argument }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -151,7 +151,7 @@ impl Filter {
                 Some(right) => return Err(unexpected_argument("upper", right)),
                 None => FilterType::Upper(UpperFilter),
             },
-            "yesno" => FilterType::Yesno(YesnoFilter::new(right)),
+            "yesno" => FilterType::Yesno(YesnoFilter::new(at, right)),
             external => {
                 let external = match parser.external_filters.get(external) {
                     Some(external) => external.clone().unbind(),

--- a/tests/filters/test_yesno.py
+++ b/tests/filters/test_yesno.py
@@ -156,12 +156,20 @@ def test_yesno_with_wrong_arg_type(assert_render_error):
 
 
 def test_yesno_with_wrong_broken_value_type(assert_render_error):
+    rusty_message = """\
+  × division by zero
+   ╭────
+ 1 │ {{ broken|yesno }}
+   ·           ──┬──
+   ·             ╰── when calling __bool__ here
+   ╰────
+"""
     assert_render_error(
         template="{{ broken|yesno }}",
         context={"broken": BrokenDunderBool()},
         exception=ZeroDivisionError,
         django_message="division by zero",
-        rusty_message="division by zero",
+        rusty_message=rusty_message,
     )
 
 


### PR DESCRIPTION
I realised we could give a better error message here by using `AnnotatePyErr`.