### PR TITLE
Add reusable `Content.resolve_usize` for future `wordwrap` filter

### DIFF
--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -2,13 +2,11 @@ use std::borrow::Cow;
 use std::sync::LazyLock;
 
 use html_escape::encode_quoted_attribute_to_string;
-use num_bigint::{BigInt, ToBigInt};
-use num_traits::ToPrimitive;
 use pyo3::prelude::*;
 use pyo3::sync::PyOnceLock;
 use pyo3::types::PyType;
 
-use crate::error::{AnnotatePyErr, RenderError};
+use crate::error::AnnotatePyErr;
 use crate::filters::{
     AddFilter, AddSlashesFilter, CapfirstFilter, CenterFilter, DefaultFilter, DefaultIfNoneFilter,
     EscapeFilter, EscapejsFilter, ExternalFilter, FilterType, LowerFilter, SafeFilter,
@@ -146,16 +144,6 @@ impl ResolveFilter for CapfirstFilter {
     }
 }
 
-fn resolve_bigint(bigint: BigInt, at: (usize, usize)) -> Result<usize, RenderError> {
-    match bigint.to_isize() {
-        Some(n) => Ok(n.max(0) as usize),
-        None => Err(RenderError::OverflowError {
-            argument: bigint.to_string(),
-            argument_at: at.into(),
-        }),
-    }
-}
-
 impl ResolveFilter for CenterFilter {
     fn resolve<'t, 'py>(
         &self,
@@ -175,49 +163,7 @@ impl ResolveFilter for CenterFilter {
             .resolve(py, template, context, ResolveFailures::Raise)?
             .expect("missing argument in context should already have raised");
 
-        let size = match arg {
-            Content::Int(left) => resolve_bigint(left, self.argument.at)?,
-            Content::String(left) => match left.as_raw().parse::<BigInt>() {
-                Ok(n) => resolve_bigint(n, self.argument.at)?,
-                Err(_) => {
-                    return Err(RenderError::InvalidArgumentInteger {
-                        argument: format!("'{}'", left.as_raw()),
-                        argument_at: self.argument.at.into(),
-                    }
-                    .into());
-                }
-            },
-            Content::Float(left) => match left.trunc().to_bigint() {
-                Some(n) => resolve_bigint(n, self.argument.at)?,
-                None => {
-                    return Err(RenderError::InvalidArgumentFloat {
-                        argument: left.to_string(),
-                        argument_at: self.argument.at.into(),
-                    }
-                    .into());
-                }
-            },
-            Content::Py(left) => match left.extract::<BigInt>() {
-                Ok(left) => resolve_bigint(left, self.argument.at)?,
-                Err(_) => {
-                    let argument = left.to_string();
-                    let argument_at = self.argument.at.into();
-                    let err = match left.extract::<f64>() {
-                        Ok(_) => RenderError::InvalidArgumentFloat {
-                            argument,
-                            argument_at,
-                        },
-                        Err(_) => RenderError::InvalidArgumentInteger {
-                            argument,
-                            argument_at,
-                        },
-                    };
-                    return Err(err.into());
-                }
-            },
-            Content::Bool(true) if content.is_empty() => return Ok(Some(" ".as_content())),
-            Content::Bool(_) => return Ok(Some(content.into_content())),
-        };
+        let size = arg.resolve_usize(self.argument.at)?;
 
         if size <= content.len() {
             return Ok(Some(content.into_content()));

--- a/tests/filters/test_center.py
+++ b/tests/filters/test_center.py
@@ -84,6 +84,16 @@ def test_center_argument_float(assert_render):
     assert_render(template, context, expected)
 
 
+@pytest.mark.parametrize("value", [True, False])
+def test_center_argument_bool(assert_render, value):
+    """Behaves like 1 and 0"""
+    template = f"{{{{ foo|center:{value} }}}}"
+    context = {"foo": "test"}
+    expected = "test"
+
+    assert_render(template, context, expected)
+
+
 def test_center_argument_negative_integer(assert_render):
     template = "{{ foo|center:-5 }}"
     context = {"foo": "test"}


### PR DESCRIPTION
I need this for `wordwrap` but I think a few others might also need it (`ljust`, `rjust`)