### PR TITLE
Make 'fn content(&self, ..)' standard and public accross Argument, FilterToken and VariableToken structs

### DIFF
--- a/dtl-lexer/src/lib.rs
+++ b/dtl-lexer/src/lib.rs
@@ -1,3 +1,5 @@
+use crate::types::TemplateString;
+
 pub mod autoescape;
 pub mod common;
 pub mod core;
@@ -15,3 +17,7 @@ const END_TAG_LEN: usize = 2;
 const START_TRANSLATE_LEN: usize = 2;
 const END_TRANSLATE_LEN: usize = 1;
 const QUOTE_LEN: usize = 1;
+
+pub trait TemplateContent<'t> {
+    fn content(&self, template: TemplateString<'t>) -> &'t str;
+}

--- a/dtl-lexer/src/types.rs
+++ b/dtl-lexer/src/types.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+use std::ops::Deref;
+
 #[derive(Clone, Copy)]
 pub struct TemplateString<'t>(pub &'t str);
 
@@ -11,5 +14,14 @@ impl<'t> TemplateString<'t> {
 impl<'t> From<&'t str> for TemplateString<'t> {
     fn from(value: &'t str) -> Self {
         TemplateString(value)
+    }
+}
+
+pub trait IntoTemplateString<'t> {
+    fn into_template_string(self) -> TemplateString<'t>;
+}
+impl<'t> IntoTemplateString<'t> for &'t str {
+    fn into_template_string(self) -> TemplateString<'t> {
+        TemplateString(self)
     }
 }


### PR DESCRIPTION
This is useful in a public API, especially since `Argument.content()` extracts the text to translate, which removes the need to make `START_TRANSLATE_LEN` and `END_TRANSLATE_LEN` public.