### PR TITLE
chore: Move crate::types::Variable to dtl_lexer::types::Variable

### DIFF
--- a/dtl-lexer/src/types.rs
+++ b/dtl-lexer/src/types.rs
@@ -1,3 +1,5 @@
+use crate::TemplateContent;
+
 #[derive(Clone, Copy)]
 pub struct TemplateString<'t>(pub &'t str);
 
@@ -20,5 +22,61 @@ pub trait IntoTemplateString<'t> {
 impl<'t> IntoTemplateString<'t> for &'t str {
     fn into_template_string(self) -> TemplateString<'t> {
         TemplateString(self)
+    }
+}
+
+pub struct PartsIterator<'t> {
+    variable: &'t str,
+    start: usize,
+}
+
+impl<'t> Iterator for PartsIterator<'t> {
+    type Item = (&'t str, (usize, usize));
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.variable.is_empty() {
+            return None;
+        }
+
+        match self.variable.find('.') {
+            Some(index) => {
+                let part = &self.variable[..index];
+                let at = (self.start, index);
+                self.start += index + 1;
+                self.variable = &self.variable[index + 1..];
+                Some((part, at))
+            }
+            None => {
+                let part = self.variable;
+                self.variable = "";
+                Some((part, (self.start, part.len())))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Variable {
+    pub at: (usize, usize),
+}
+
+impl<'t> Variable {
+    pub fn new(at: (usize, usize)) -> Self {
+        Self { at }
+    }
+
+    pub fn parts(
+        &self,
+        template: TemplateString<'t>,
+    ) -> impl Iterator<Item = (&'t str, (usize, usize))> {
+        let start = self.at.0;
+        let variable = template.content(self.at);
+        PartsIterator { variable, start }
+    }
+}
+
+impl<'t> TemplateContent<'t> for Variable {
+    fn content(&self, template: TemplateString<'t>) -> &'t str {
+        template.content(self.at)
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -43,7 +43,7 @@ use dtl_lexer::tag::{TagLexerError, TagParts, lex_tag};
 use dtl_lexer::types::TemplateString;
 use dtl_lexer::variable::{
     Argument as ArgumentToken, ArgumentType as ArgumentTokenType, VariableLexerError,
-    VariableTokenType, lex_variable,
+    VariableToken, lex_variable,
 };
 
 use crate::types::Argument;
@@ -53,7 +53,7 @@ use crate::types::ForVariableName;
 
 use crate::types::Text;
 use crate::types::TranslatedText;
-use crate::types::Variable;
+use dtl_lexer::types::Variable;
 
 trait Parse<R> {
     fn parse(&self, parser: &Parser) -> Result<R, ParseError>;
@@ -1095,10 +1095,10 @@ impl<'t, 'l, 'py> Parser<'t, 'l, 'py> {
         let Some((variable_token, filter_lexer)) = lex_variable(variable, start)? else {
             return Err(ParseError::EmptyVariable { at: at.into() });
         };
-        let mut var = match variable_token.token_type {
-            VariableTokenType::Variable => self.parse_for_variable(variable_token.at).into(),
-            VariableTokenType::Int(n) => TagElement::Int(n),
-            VariableTokenType::Float(f) => TagElement::Float(f),
+        let mut var = match variable_token {
+            VariableToken::Variable(var) => self.parse_for_variable(var.at).into(),
+            VariableToken::Int(n) => TagElement::Int(n),
+            VariableToken::Float(f) => TagElement::Float(f),
         };
         for filter_token in filter_lexer {
             let filter_token = filter_token?;

--- a/src/render/common.rs
+++ b/src/render/common.rs
@@ -16,7 +16,7 @@ use crate::types::ForVariable;
 use crate::types::ForVariableName;
 use crate::types::Text;
 use crate::types::TranslatedText;
-use crate::types::Variable;
+use dtl_lexer::types::Variable;
 
 /// Helper function to translate a string using Django's gettext
 pub fn gettext(py: Python<'_>, text: &str) -> PyResult<String> {

--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -553,7 +553,7 @@ mod tests {
     use crate::parse::TagElement;
     use crate::render::Render;
     use crate::template::django_rusty_templates::{EngineData, Template};
-    use crate::types::{Argument, ArgumentType, Text, Variable};
+    use crate::types::{Argument, ArgumentType, Text};
 
     use pyo3::types::{PyDict, PyString};
     static MARK_SAFE: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
@@ -572,6 +572,7 @@ mod tests {
         Ok(safe_string)
     }
 
+    use dtl_lexer::types::Variable;
     use std::collections::HashMap;
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,36 +1,6 @@
 use num_bigint::BigInt;
 
-use dtl_lexer::types::TemplateString;
-
-struct PartsIterator<'t> {
-    variable: &'t str,
-    start: usize,
-}
-
-impl<'t> Iterator for PartsIterator<'t> {
-    type Item = (&'t str, (usize, usize));
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.variable.is_empty() {
-            return None;
-        }
-
-        match self.variable.find('.') {
-            Some(index) => {
-                let part = &self.variable[..index];
-                let at = (self.start, index);
-                self.start += index + 1;
-                self.variable = &self.variable[index + 1..];
-                Some((part, at))
-            }
-            None => {
-                let part = self.variable;
-                self.variable = "";
-                Some((part, (self.start, part.len())))
-            }
-        }
-    }
-}
+use dtl_lexer::types::Variable;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Text {
@@ -51,26 +21,6 @@ pub struct TranslatedText {
 impl TranslatedText {
     pub fn new(at: (usize, usize)) -> Self {
         Self { at }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Variable {
-    pub at: (usize, usize),
-}
-
-impl<'t> Variable {
-    pub fn new(at: (usize, usize)) -> Self {
-        Self { at }
-    }
-
-    pub fn parts(
-        &self,
-        template: TemplateString<'t>,
-    ) -> impl Iterator<Item = (&'t str, (usize, usize))> {
-        let start = self.at.0;
-        let variable = template.content(self.at);
-        PartsIterator { variable, start }
     }
 }
 


### PR DESCRIPTION
This is part of an effort to move more parts of tag parsing into the `dtls-lexer` crate as I'm beginning to implement tag rendering in django-template-transpiler. Starting with `Variable` and integrating it with `VariableTokenType` will allow me to support `{{ var.subvar.subsubvar }}` which DTT doesn't support yet.