### PR TITLE
Rename Template::_render to render and make it public

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2097,7 +2097,7 @@ mod tests {
             let context = PyDict::new(py);
             context.set_item("bar", "").unwrap();
             let template = Template::new_from_string(py, template_string, engine.clone()).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "");
 

--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -706,7 +706,7 @@ mod tests {
             let context = PyDict::new(py);
             context.set_item("var", "hello world").unwrap();
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "hello-world");
         });
@@ -722,7 +722,7 @@ mod tests {
             let context = PyDict::new(py);
             context.set_item("var", " hello world").unwrap();
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "hello-world");
         });
@@ -738,7 +738,7 @@ mod tests {
             let context = PyDict::new(py);
             context.set_item("var", "a&€%").unwrap();
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "a");
         });
@@ -754,7 +754,7 @@ mod tests {
             let context = PyDict::new(py);
             context.set_item("var", "a & b").unwrap();
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "a-b");
         });
@@ -769,7 +769,7 @@ mod tests {
             let template_string = "{{ var|default:1|slugify }}".to_string();
             let context = PyDict::new(py);
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "1");
         });
@@ -784,7 +784,7 @@ mod tests {
             let template_string = "{{ var|default:1.3|slugify }}".to_string();
             let context = PyDict::new(py);
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "1.3");
         });
@@ -799,7 +799,7 @@ mod tests {
             let template_string = "{{ var|default:'hello world'|slugify }}".to_string();
             let context = PyDict::new(py);
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "hello-world");
         });
@@ -814,7 +814,7 @@ mod tests {
             let template_string = "{{ var|default:'hello world'|safe|slugify }}".to_string();
             let context = PyDict::new(py);
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "hello-world");
         });
@@ -831,7 +831,7 @@ mod tests {
             let safe_string = mark_safe(py, "a &amp; b".to_string()).unwrap();
             context.set_item("var", safe_string).unwrap();
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "a-amp-b");
         });
@@ -846,7 +846,7 @@ mod tests {
             let template_string = "{{ not_there|slugify }}".to_string();
             let context = PyDict::new(py);
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "");
         });
@@ -897,7 +897,7 @@ mod tests {
             let context = PyDict::new(py);
             context.set_item("var", "hello world").unwrap();
             let template = Template::new_from_string(py, template_string, engine.clone()).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "Hello world");
 
@@ -905,7 +905,7 @@ mod tests {
             context.set_item("var", "").unwrap();
             let template_string = "{{ var|capfirst }}".to_string();
             let template = Template::new_from_string(py, template_string, engine.clone()).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "");
 
@@ -913,7 +913,7 @@ mod tests {
             context.set_item("bar", "").unwrap();
             let template_string = "{{ var|capfirst }}".to_string();
             let template = Template::new_from_string(py, template_string, engine.clone()).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "");
 
@@ -935,7 +935,7 @@ mod tests {
             let context = PyDict::new(py);
             context.set_item("var", "hello").unwrap();
             let template = Template::new_from_string(py, template_string, engine.clone()).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "   hello   ");
 
@@ -943,7 +943,7 @@ mod tests {
             context.set_item("var", "django").unwrap();
             let template_string = "{{ var|center:'15' }}".to_string();
             let template = Template::new_from_string(py, template_string, engine.clone()).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "     django    ");
 
@@ -951,7 +951,7 @@ mod tests {
             context.set_item("var", "django").unwrap();
             let template_string = "{{ var|center:1 }}".to_string();
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "django");
         });
@@ -983,7 +983,7 @@ mod tests {
             let template_string = "{{ var|center:'11' }}".to_string();
             let context = PyDict::new(py);
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "");
         });
@@ -999,7 +999,7 @@ mod tests {
             let context = PyDict::new(py);
             context.set_item("var", "hello").unwrap();
             let template = Template::new_from_string(py, template_string, engine).unwrap();
-            let result = template.render(py, Some(context), None).unwrap();
+            let result = template.py_render(py, Some(context), None).unwrap();
 
             assert_eq!(result, "hello");
         });

--- a/src/template.rs
+++ b/src/template.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 
 #[pymodule]
 pub mod django_rusty_templates {
+    use std::borrow::Cow;
     use std::collections::HashMap;
     use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
@@ -19,8 +20,8 @@ pub mod django_rusty_templates {
     use crate::error::RenderError;
     use crate::loaders::{AppDirsLoader, CachedLoader, FileSystemLoader, Loader, LocMemLoader};
     use crate::parse::{Parser, TokenTree};
-    use crate::render::Render;
     use crate::render::types::Context;
+    use crate::render::{Render, RenderResult};
     use crate::utils::PyResultMethods;
     use dtl_lexer::types::TemplateString;
 
@@ -413,7 +414,7 @@ pub mod django_rusty_templates {
                 self.get_template(py, template_name.extract()?)?
             };
 
-            template.render(py, context, None)
+            template.py_render(py, context, None)
         }
 
         #[getter]
@@ -525,49 +526,21 @@ pub mod django_rusty_templates {
             })
         }
 
-        fn _render(&self, py: Python<'_>, context: &mut Context) -> PyResult<String> {
+        pub fn render(&self, py: Python<'_>, context: &mut Context) -> RenderResult<'_> {
             let mut rendered = String::with_capacity(self.template.len());
             let template = TemplateString(&self.template);
             for node in &self.nodes {
-                match node.render(py, template, context) {
-                    Ok(content) => rendered.push_str(&content),
-                    Err(err) => {
-                        let err = err.try_into_render_error()?;
-                        match err {
-                            RenderError::VariableDoesNotExist { .. }
-                            | RenderError::ArgumentDoesNotExist { .. } => {
-                                return Err(VariableDoesNotExist::with_source_code(
-                                    err.into(),
-                                    self.template.clone(),
-                                ));
-                            }
-                            RenderError::InvalidArgumentInteger { .. }
-                            | RenderError::InvalidArgumentString { .. }
-                            | RenderError::TupleUnpackError { .. } => {
-                                return Err(PyValueError::with_source_code(
-                                    err.into(),
-                                    self.template.clone(),
-                                ));
-                            }
-                            RenderError::OverflowError { .. }
-                            | RenderError::InvalidArgumentFloat { .. } => {
-                                return Err(PyOverflowError::with_source_code(
-                                    err.into(),
-                                    self.template.clone(),
-                                ));
-                            }
-                        }
-                    }
-                }
+                let content = node.render(py, template, context)?;
+                rendered.push_str(&content);
             }
-            Ok(rendered)
+            Ok(Cow::Owned(rendered))
         }
     }
 
     #[pymethods]
     impl Template {
-        #[pyo3(signature = (context=None, request=None))]
-        pub fn render(
+        #[pyo3(name = "render", signature = (context=None, request=None))]
+        pub fn py_render(
             &self,
             py: Python<'_>,
             context: Option<Bound<'_, PyDict>>,
@@ -606,7 +579,31 @@ pub mod django_rusty_templates {
                 base_context.extend(new_context);
             }
             let mut context = Context::new(base_context, request, self.engine.autoescape);
-            self._render(py, &mut context)
+
+            match self.render(py, &mut context) {
+                Ok(content) => Ok(content.to_string()),
+                Err(err) => {
+                    let err = err.try_into_render_error()?;
+                    match err {
+                        RenderError::VariableDoesNotExist { .. }
+                        | RenderError::ArgumentDoesNotExist { .. } => {
+                            Err(VariableDoesNotExist::with_source_code(
+                                err.into(),
+                                self.template.clone(),
+                            ))
+                        }
+                        RenderError::InvalidArgumentInteger { .. }
+                        | RenderError::InvalidArgumentString { .. }
+                        | RenderError::TupleUnpackError { .. } => Err(
+                            PyValueError::with_source_code(err.into(), self.template.clone()),
+                        ),
+                        RenderError::OverflowError { .. }
+                        | RenderError::InvalidArgumentFloat { .. } => Err(
+                            PyOverflowError::with_source_code(err.into(), self.template.clone()),
+                        ),
+                    }
+                }
+            }
         }
     }
 }
@@ -686,7 +683,7 @@ mod tests {
             let template = Template::new_from_string(py, template_string, engine).unwrap();
             let context = PyDict::new(py);
 
-            assert_eq!(template.render(py, Some(context), None).unwrap(), "");
+            assert_eq!(template.py_render(py, Some(context), None).unwrap(), "");
         });
     }
 
@@ -702,7 +699,7 @@ mod tests {
             context.set_item("user", "Lily").unwrap();
 
             assert_eq!(
-                template.render(py, Some(context), None).unwrap(),
+                template.py_render(py, Some(context), None).unwrap(),
                 "Hello Lily!"
             );
         });
@@ -718,7 +715,10 @@ mod tests {
             let template = Template::new_from_string(py, template_string, engine).unwrap();
             let context = PyDict::new(py);
 
-            assert_eq!(template.render(py, Some(context), None).unwrap(), "Hello !");
+            assert_eq!(
+                template.py_render(py, Some(context), None).unwrap(),
+                "Hello !"
+            );
         });
     }
 
@@ -748,7 +748,7 @@ user = User(["Lily"])
             context.set_item("user", user.into_any()).unwrap();
 
             assert_eq!(
-                template.render(py, Some(context), None).unwrap(),
+                template.py_render(py, Some(context), None).unwrap(),
                 "Hello Lily!"
             );
         });
@@ -777,7 +777,10 @@ user = User(["Lily"])
             let template = engine.from_string(template_string).unwrap();
             let context = PyDict::new(py);
 
-            assert_eq!(template.render(py, Some(context), None).unwrap(), "Hello !");
+            assert_eq!(
+                template.py_render(py, Some(context), None).unwrap(),
+                "Hello !"
+            );
         });
     }
 


### PR DESCRIPTION
Also rename `Template::render` to `py_render` in Rust code to reduce confusion.

Finally, change the return type of the new `render` method to `RenderResult` to allow re-use from `{% include %}` tags.