### PR TITLE
Refactor lex_variable

### DIFF
--- a/dtl-lexer/src/autoescape.rs
+++ b/dtl-lexer/src/autoescape.rs
@@ -2,7 +2,7 @@ use miette::{Diagnostic, SourceSpan};
 use thiserror::Error;
 
 use crate::tag::TagParts;
-use crate::types::TemplateString;
+use crate::types::{At, TemplateString};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum AutoescapeEnabled {
@@ -21,7 +21,7 @@ impl From<&AutoescapeEnabled> for bool {
 
 #[derive(Debug, PartialEq)]
 pub struct AutoescapeToken {
-    pub at: (usize, usize),
+    pub at: At,
     pub enabled: AutoescapeEnabled,
 }
 

--- a/dtl-lexer/src/core.rs
+++ b/dtl-lexer/src/core.rs
@@ -1,4 +1,4 @@
-use crate::types::TemplateString;
+use crate::types::{At, TemplateString};
 use crate::{END_TAG_LEN, START_TAG_LEN};
 
 enum EndTag {
@@ -18,32 +18,32 @@ pub enum TokenType {
 #[derive(Debug, PartialEq, Eq)]
 pub struct Token {
     pub token_type: TokenType,
-    pub at: (usize, usize),
+    pub at: At,
 }
 
 impl Token {
-    fn text(at: (usize, usize)) -> Self {
+    fn text(at: At) -> Self {
         Self {
             at,
             token_type: TokenType::Text,
         }
     }
 
-    fn variable(at: (usize, usize)) -> Self {
+    fn variable(at: At) -> Self {
         Self {
             at,
             token_type: TokenType::Variable,
         }
     }
 
-    fn tag(at: (usize, usize)) -> Self {
+    fn tag(at: At) -> Self {
         Self {
             at,
             token_type: TokenType::Tag,
         }
     }
 
-    fn comment(at: (usize, usize)) -> Self {
+    fn comment(at: At) -> Self {
         Self {
             at,
             token_type: TokenType::Comment,

--- a/dtl-lexer/src/custom_tag.rs
+++ b/dtl-lexer/src/custom_tag.rs
@@ -7,7 +7,7 @@ use crate::common::{
     translated_text_content_at,
 };
 use crate::tag::TagParts;
-use crate::types::TemplateString;
+use crate::types::{At, TemplateString};
 
 #[derive(Debug, PartialEq)]
 pub enum SimpleTagTokenType {
@@ -19,13 +19,13 @@ pub enum SimpleTagTokenType {
 
 #[derive(Debug, PartialEq)]
 pub struct SimpleTagToken {
-    pub at: (usize, usize),
+    pub at: At,
     pub token_type: SimpleTagTokenType,
-    pub kwarg: Option<(usize, usize)>,
+    pub kwarg: Option<At>,
 }
 
 impl SimpleTagToken {
-    pub fn content_at(&self) -> (usize, usize) {
+    pub fn content_at(&self) -> At {
         match self.token_type {
             SimpleTagTokenType::Variable => self.at,
             SimpleTagTokenType::Numeric => self.at,
@@ -60,7 +60,7 @@ impl<'t> SimpleTagLexer<'t> {
         }
     }
 
-    fn lex_numeric(&mut self, kwarg: Option<(usize, usize)>) -> SimpleTagToken {
+    fn lex_numeric(&mut self, kwarg: Option<At>) -> SimpleTagToken {
         let (at, byte, rest) = lex_numeric(self.byte, self.rest);
         self.rest = rest;
         self.byte = byte;
@@ -75,7 +75,7 @@ impl<'t> SimpleTagLexer<'t> {
         &mut self,
         chars: &mut std::str::Chars,
         end: char,
-        kwarg: Option<(usize, usize)>,
+        kwarg: Option<At>,
     ) -> Result<SimpleTagToken, SimpleTagLexerError> {
         match lex_text(self.byte, self.rest, chars, end) {
             Ok((at, byte, rest)) => {
@@ -97,7 +97,7 @@ impl<'t> SimpleTagLexer<'t> {
     fn lex_translated(
         &mut self,
         chars: &mut std::str::Chars,
-        kwarg: Option<(usize, usize)>,
+        kwarg: Option<At>,
     ) -> Result<SimpleTagToken, SimpleTagLexerError> {
         match lex_translated(self.byte, self.rest, chars) {
             Ok((at, byte, rest)) => {
@@ -116,7 +116,7 @@ impl<'t> SimpleTagLexer<'t> {
         }
     }
 
-    fn lex_kwarg(&mut self) -> Option<(usize, usize)> {
+    fn lex_kwarg(&mut self) -> Option<At> {
         let index = self.rest.find('=')?;
         match self.rest.find(|c: char| !c.is_xid_continue()) {
             Some(n) if n < index => return None,
@@ -130,7 +130,7 @@ impl<'t> SimpleTagLexer<'t> {
 
     fn lex_variable_or_filter(
         &mut self,
-        kwarg: Option<(usize, usize)>,
+        kwarg: Option<At>,
     ) -> Result<SimpleTagToken, SimpleTagLexerError> {
         let (at, byte, rest) = lex_variable(self.byte, self.rest);
         self.rest = rest;

--- a/dtl-lexer/src/forloop.rs
+++ b/dtl-lexer/src/forloop.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use crate::common::{LexerError, NextChar, lex_numeric, lex_text, lex_translated, lex_variable};
 use crate::tag::TagParts;
-use crate::types::TemplateString;
+use crate::types::{At, TemplateString};
 
 #[derive(Clone, Error, Debug, Diagnostic, PartialEq, Eq)]
 pub enum ForLexerError {
@@ -51,12 +51,12 @@ pub enum ForTokenType {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ForVariableNameToken {
-    pub at: (usize, usize),
+    pub at: At,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ForVariableToken {
-    pub at: (usize, usize),
+    pub at: At,
     pub token_type: ForTokenType,
 }
 
@@ -69,7 +69,7 @@ pub struct ForLexer<'t> {
     rest: &'t str,
     byte: usize,
     state: State,
-    previous_at: Option<(usize, usize)>,
+    previous_at: Option<At>,
 }
 
 impl<'t> ForLexer<'t> {

--- a/dtl-lexer/src/ifcondition.rs
+++ b/dtl-lexer/src/ifcondition.rs
@@ -3,7 +3,7 @@ use crate::common::{
     translated_text_content_at,
 };
 use crate::tag::TagParts;
-use crate::types::TemplateString;
+use crate::types::{At, TemplateString};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum IfConditionAtom {
@@ -38,12 +38,12 @@ pub enum IfConditionTokenType {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct IfConditionToken {
-    pub at: (usize, usize),
+    pub at: At,
     pub token_type: IfConditionTokenType,
 }
 
 impl IfConditionToken {
-    pub fn content_at(&self) -> (usize, usize) {
+    pub fn content_at(&self) -> At {
         match self.token_type {
             IfConditionTokenType::Atom(IfConditionAtom::Text) => text_content_at(self.at),
             IfConditionTokenType::Atom(IfConditionAtom::TranslatedText) => {

--- a/dtl-lexer/src/load.rs
+++ b/dtl-lexer/src/load.rs
@@ -1,10 +1,10 @@
 use crate::common::NextChar;
 use crate::tag::TagParts;
-use crate::types::TemplateString;
+use crate::types::{At, TemplateString};
 
 #[derive(Debug, PartialEq)]
 pub struct LoadToken {
-    pub at: (usize, usize),
+    pub at: At,
 }
 
 pub struct LoadLexer<'t> {

--- a/dtl-lexer/src/tag.rs
+++ b/dtl-lexer/src/tag.rs
@@ -4,7 +4,7 @@ use unicode_xid::UnicodeXID;
 
 use crate::TemplateContent;
 use crate::common::NextChar;
-use crate::types::TemplateString;
+use crate::types::{At, TemplateString};
 
 #[derive(Error, Debug, Diagnostic, Eq, PartialEq)]
 pub enum TagLexerError {
@@ -17,7 +17,7 @@ pub enum TagLexerError {
 
 #[derive(Debug, PartialEq)]
 pub struct TagToken {
-    pub at: (usize, usize),
+    pub at: At,
 }
 
 impl<'t> TemplateContent<'t> for TagToken {
@@ -28,7 +28,7 @@ impl<'t> TemplateContent<'t> for TagToken {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TagParts {
-    pub at: (usize, usize),
+    pub at: At,
 }
 
 impl<'t> TemplateContent<'t> for TagParts {

--- a/dtl-lexer/src/types.rs
+++ b/dtl-lexer/src/types.rs
@@ -1,10 +1,12 @@
 use crate::TemplateContent;
 
+pub type At = (usize, usize);
+
 #[derive(Clone, Copy)]
 pub struct TemplateString<'t>(pub &'t str);
 
 impl<'t> TemplateString<'t> {
-    pub fn content(&self, at: (usize, usize)) -> &'t str {
+    pub fn content(&self, at: At) -> &'t str {
         let (start, len) = at;
         &self.0[start..start + len]
     }
@@ -31,7 +33,7 @@ pub struct PartsIterator<'t> {
 }
 
 impl<'t> Iterator for PartsIterator<'t> {
-    type Item = (&'t str, (usize, usize));
+    type Item = (&'t str, At);
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.variable.is_empty() {
@@ -57,18 +59,15 @@ impl<'t> Iterator for PartsIterator<'t> {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Variable {
-    pub at: (usize, usize),
+    pub at: At,
 }
 
 impl<'t> Variable {
-    pub fn new(at: (usize, usize)) -> Self {
+    pub fn new(at: At) -> Self {
         Self { at }
     }
 
-    pub fn parts(
-        &self,
-        template: TemplateString<'t>,
-    ) -> impl Iterator<Item = (&'t str, (usize, usize))> {
+    pub fn parts(&self, template: TemplateString<'t>) -> impl Iterator<Item = (&'t str, At)> {
         let start = self.at.0;
         let variable = template.content(self.at);
         PartsIterator { variable, start }

--- a/dtl-lexer/src/variable.rs
+++ b/dtl-lexer/src/variable.rs
@@ -7,7 +7,7 @@ use crate::common::{
     LexerError, NextChar, check_variable_attrs, lex_numeric, lex_text, lex_translated,
     lex_variable_argument, trim_variable,
 };
-use crate::types::TemplateString;
+use crate::types::{At, TemplateString};
 use crate::{END_TRANSLATE_LEN, QUOTE_LEN, START_TRANSLATE_LEN, TemplateContent};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -21,11 +21,11 @@ pub enum ArgumentType {
 #[derive(Debug, PartialEq, Eq)]
 pub struct Argument {
     pub argument_type: ArgumentType,
-    pub at: (usize, usize),
+    pub at: At,
 }
 
 impl Argument {
-    pub fn content_at(&self) -> (usize, usize) {
+    pub fn content_at(&self) -> At {
         match self.argument_type {
             ArgumentType::Variable => self.at,
             ArgumentType::Numeric => self.at,
@@ -54,7 +54,7 @@ impl<'t> TemplateContent<'t> for Argument {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct FilterToken {
-    pub at: (usize, usize),
+    pub at: At,
     pub argument: Option<Argument>,
 }
 
@@ -93,8 +93,6 @@ pub enum VariableLexerError {
         at: SourceSpan,
     },
 }
-
-type At = (usize, usize);
 
 pub fn lex_variable_or_filter(
     variable: &str,

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use pyo3::exceptions::PyKeyError;
 use pyo3::prelude::*;
 use thiserror::Error;
 
-use dtl_lexer::types::TemplateString;
+use dtl_lexer::types::{At, TemplateString};
 
 #[derive(Error, Debug)]
 pub enum PyRenderError {
@@ -89,23 +89,11 @@ impl KeyErrorMessage {
 }
 
 pub trait AnnotatePyErr {
-    fn annotate(
-        self,
-        py: Python<'_>,
-        at: (usize, usize),
-        label: &str,
-        template: TemplateString<'_>,
-    ) -> Self;
+    fn annotate(self, py: Python<'_>, at: At, label: &str, template: TemplateString<'_>) -> Self;
 }
 
 impl AnnotatePyErr for PyErr {
-    fn annotate(
-        self,
-        py: Python<'_>,
-        at: (usize, usize),
-        label: &str,
-        template: TemplateString<'_>,
-    ) -> Self {
+    fn annotate(self, py: Python<'_>, at: At, label: &str, template: TemplateString<'_>) -> Self {
         let message = miette!(
             labels = vec![LabeledSpan::at(at, label)],
             "{}",

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use pyo3::prelude::*;
 
 use crate::types::Argument;
+use dtl_lexer::types::At;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum FilterType {
@@ -137,12 +138,12 @@ impl WordwrapFilter {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct YesnoFilter {
-    pub at: (usize, usize),
+    pub at: At,
     pub argument: Option<Argument>,
 }
 
 impl YesnoFilter {
-    pub fn new(at: (usize, usize), argument: Option<Argument>) -> Self {
+    pub fn new(at: At, argument: Option<Argument>) -> Self {
         Self { at, argument }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -41,7 +41,7 @@ use dtl_lexer::ifcondition::{
 };
 use dtl_lexer::load::{LoadLexer, LoadToken};
 use dtl_lexer::tag::{TagLexerError, TagParts, lex_tag};
-use dtl_lexer::types::TemplateString;
+use dtl_lexer::types::{At, TemplateString};
 use dtl_lexer::variable::{
     Argument as ArgumentToken, ArgumentType as ArgumentTokenType, VariableLexerError,
     VariableToken, lex_variable_or_filter,
@@ -104,7 +104,7 @@ fn unexpected_argument(filter: &'static str, right: Argument) -> ParseError {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Filter {
-    pub at: (usize, usize),
+    pub at: At,
     pub left: TagElement,
     pub filter: FilterType,
 }
@@ -112,7 +112,7 @@ pub struct Filter {
 impl Filter {
     pub fn new(
         parser: &Parser,
-        at: (usize, usize),
+        at: At,
         left: TagElement,
         right: Option<Argument>,
     ) -> Result<Self, ParseError> {
@@ -195,7 +195,7 @@ impl Filter {
     }
 }
 
-fn parse_numeric(content: &str, at: (usize, usize)) -> Result<TagElement, ParseError> {
+fn parse_numeric(content: &str, at: At) -> Result<TagElement, ParseError> {
     match content.parse::<BigInt>() {
         Ok(n) => Ok(TagElement::Int(n)),
         Err(_) => match content.parse::<f64>() {
@@ -250,7 +250,7 @@ pub enum IfCondition {
 fn parse_if_condition(
     parser: &mut Parser,
     parts: TagParts,
-    at: (usize, usize),
+    at: At,
 ) -> Result<IfCondition, ParseError> {
     let mut lexer = IfConditionLexer::new(parser.template, parts).peekable();
     if lexer.peek().is_none() {
@@ -263,7 +263,7 @@ fn parse_if_binding_power(
     parser: &mut Parser,
     lexer: &mut Peekable<IfConditionLexer>,
     min_binding_power: u8,
-    at: (usize, usize),
+    at: At,
 ) -> Result<IfCondition, ParseError> {
     let Some(token) = lexer.next().transpose()? else {
         return Err(ParseError::UnexpectedEndExpression { at: at.into() });
@@ -375,19 +375,19 @@ impl IfConditionOperatorMethods for IfConditionOperator {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ForIterable {
     pub iterable: TagElement,
-    pub at: (usize, usize),
+    pub at: At,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ForNames {
     pub names: Vec<String>,
-    pub at: (usize, usize),
+    pub at: At,
 }
 
 fn parse_for_loop(
     parser: &mut Parser,
     parts: TagParts,
-    at: (usize, usize),
+    at: At,
 ) -> Result<(ForIterable, ForNames, bool), ParseError> {
     let mut lexer = ForLexer::new(parser.template, parts);
     let mut variable_names = Vec::new();
@@ -470,7 +470,7 @@ pub struct For {
 #[derive(Clone, Debug)]
 pub struct SimpleTag {
     pub func: Arc<Py<PyAny>>,
-    pub at: (usize, usize),
+    pub at: At,
     pub takes_context: bool,
     pub args: Vec<TagElement>,
     pub kwargs: Vec<(String, TagElement)>,
@@ -496,7 +496,7 @@ impl PartialEq for SimpleTag {
 pub struct SimpleBlockTag {
     pub func: Arc<Py<PyAny>>,
     pub nodes: Vec<TokenTree>,
-    pub at: (usize, usize),
+    pub at: At,
     pub takes_context: bool,
     pub args: Vec<TagElement>,
     pub kwargs: Vec<(String, TagElement)>,
@@ -567,7 +567,7 @@ impl EndTagType {
 
 #[derive(PartialEq, Eq)]
 struct EndTag {
-    at: (usize, usize),
+    at: At,
     end: EndTagType,
     parts: TagParts,
 }
@@ -993,7 +993,7 @@ impl<'t, 'py> Parser<'t, 'py> {
         &mut self,
         until: Vec<EndTagType>,
         start: Cow<'static, str>,
-        start_at: (usize, usize),
+        start_at: At,
     ) -> Result<(Vec<TokenTree>, EndTag), PyParseError> {
         let mut nodes = Vec::new();
         while let Some(token) = self.lexer.next() {
@@ -1041,7 +1041,7 @@ impl<'t, 'py> Parser<'t, 'py> {
         .into())
     }
 
-    fn parse_for_variable(&self, at: (usize, usize)) -> Either<Variable, ForVariable> {
+    fn parse_for_variable(&self, at: At) -> Either<Variable, ForVariable> {
         let mut parts = self.template.content(at).split('.');
         if self.forloop_depth == 0
             || parts
@@ -1090,7 +1090,7 @@ impl<'t, 'py> Parser<'t, 'py> {
     fn parse_variable(
         &self,
         variable: &str,
-        at: (usize, usize),
+        at: At,
         start: usize,
     ) -> Result<TagElement, ParseError> {
         let Some((variable_token, at, filter_lexer)) = lex_variable_or_filter(variable, start)?
@@ -1117,7 +1117,7 @@ impl<'t, 'py> Parser<'t, 'py> {
     fn parse_tag(
         &mut self,
         tag: &'t str,
-        at: (usize, usize),
+        at: At,
     ) -> Result<Either<TokenTree, EndTag>, PyParseError> {
         let maybe_tag = match lex_tag(tag, at.0 + START_TAG_LEN) {
             Ok(maybe_tag) => maybe_tag,
@@ -1205,7 +1205,7 @@ impl<'t, 'py> Parser<'t, 'py> {
 
         let parts_at = parts.at;
         let mut prev_at = parts.at;
-        let mut seen_kwargs: HashMap<&str, (usize, usize)> = HashMap::new();
+        let mut seen_kwargs: HashMap<&str, At> = HashMap::new();
         let params_count = context.params.len();
         let mut tokens =
             SimpleTagLexer::new(self.template, parts).collect::<Result<Vec<_>, _>>()?;
@@ -1297,7 +1297,7 @@ impl<'t, 'py> Parser<'t, 'py> {
     fn parse_simple_tag(
         &self,
         context: &SimpleTagContext,
-        at: (usize, usize),
+        at: At,
         parts: TagParts,
     ) -> Result<TokenTree, PyParseError> {
         let (args, kwargs, target_var) = self.parse_custom_tag_parts(parts, context)?;
@@ -1317,7 +1317,7 @@ impl<'t, 'py> Parser<'t, 'py> {
         context: SimpleTagContext,
         tag_name: String,
         end_tag_name: String,
-        at: (usize, usize),
+        at: At,
         parts: TagParts,
     ) -> Result<TokenTree, PyParseError> {
         let (args, kwargs, target_var) = self.parse_custom_tag_parts(parts, &context)?;
@@ -1338,11 +1338,7 @@ impl<'t, 'py> Parser<'t, 'py> {
         Ok(TokenTree::Tag(Tag::SimpleBlockTag(tag)))
     }
 
-    fn parse_load(
-        &mut self,
-        at: (usize, usize),
-        parts: TagParts,
-    ) -> Result<TokenTree, PyParseError> {
+    fn parse_load(&mut self, at: At, parts: TagParts) -> Result<TokenTree, PyParseError> {
         let tokens: Vec<_> = LoadLexer::new(self.template, parts).collect();
         let mut rev = tokens.iter().rev();
         if let (Some(last), Some(prev)) = (rev.next(), rev.next())
@@ -1385,7 +1381,7 @@ impl<'t, 'py> Parser<'t, 'py> {
     #[allow(clippy::too_many_lines)]
     fn load_tag(
         &mut self,
-        at: (usize, usize),
+        at: At,
         name: &str,
         tag: &Bound<'py, PyAny>,
     ) -> Result<(), PyParseError> {
@@ -1518,7 +1514,7 @@ impl<'t, 'py> Parser<'t, 'py> {
         library.getattr(intern!(self.py, "filters"))?.extract()
     }
 
-    fn parse_url(&self, at: (usize, usize), parts: TagParts) -> Result<TokenTree, ParseError> {
+    fn parse_url(&self, at: At, parts: TagParts) -> Result<TokenTree, ParseError> {
         let mut lexer = SimpleTagLexer::new(self.template, parts);
         let Some(view_token) = lexer.next() else {
             return Err(ParseError::UrlTagNoArguments { at: at.into() });
@@ -1579,11 +1575,7 @@ impl<'t, 'py> Parser<'t, 'py> {
         Ok(TokenTree::Tag(Tag::Url(url)))
     }
 
-    fn parse_autoescape(
-        &mut self,
-        at: (usize, usize),
-        parts: TagParts,
-    ) -> Result<TokenTree, PyParseError> {
+    fn parse_autoescape(&mut self, at: At, parts: TagParts) -> Result<TokenTree, PyParseError> {
         let token = lex_autoescape_argument(self.template, parts).map_err(ParseError::from)?;
         let (nodes, _) = self.parse_until(vec![EndTagType::Autoescape], "autoescape".into(), at)?;
         Ok(TokenTree::Tag(Tag::Autoescape {
@@ -1594,7 +1586,7 @@ impl<'t, 'py> Parser<'t, 'py> {
 
     fn parse_if(
         &mut self,
-        at: (usize, usize),
+        at: At,
         parts: TagParts,
         start: &'static str,
     ) -> Result<TokenTree, PyParseError> {
@@ -1632,11 +1624,7 @@ impl<'t, 'py> Parser<'t, 'py> {
         }))
     }
 
-    fn parse_for(
-        &mut self,
-        at: (usize, usize),
-        parts: TagParts,
-    ) -> Result<TokenTree, PyParseError> {
+    fn parse_for(&mut self, at: At, parts: TagParts) -> Result<TokenTree, PyParseError> {
         self.forloop_depth += 1;
         let (iterable, variables, reversed) = parse_for_loop(self, parts, at)?;
         let (nodes, end_tag) = self.parse_until(

--- a/src/render/tags.rs
+++ b/src/render/tags.rs
@@ -9,7 +9,7 @@ use pyo3::prelude::*;
 use pyo3::sync::MutexExt;
 use pyo3::types::{PyBool, PyDict, PyList, PyNone, PyString, PyTuple};
 
-use dtl_lexer::types::TemplateString;
+use dtl_lexer::types::{At, TemplateString};
 
 use super::types::{AsBorrowedContent, Content, Context, PyContext};
 use super::{Evaluate, Render, RenderResult, Resolve, ResolveFailures, ResolveResult};
@@ -768,7 +768,7 @@ impl Render for For {
 fn call_tag<'t>(
     py: Python<'_>,
     func: &Arc<Py<PyAny>>,
-    at: (usize, usize),
+    at: At,
     template: TemplateString<'t>,
     args: VecDeque<Bound<'_, PyAny>>,
     kwargs: Bound<'_, PyDict>,

--- a/src/render/types.rs
+++ b/src/render/types.rs
@@ -17,7 +17,7 @@ use pyo3::types::{PyBool, PyDict, PyInt, PyString, PyType};
 
 use crate::error::{AnnotatePyErr, PyRenderError, RenderError};
 use crate::utils::PyResultMethods;
-use dtl_lexer::types::TemplateString;
+use dtl_lexer::types::{At, TemplateString};
 
 #[derive(Debug, Clone)]
 pub struct ForLoop {
@@ -136,9 +136,9 @@ impl Context {
     pub fn push_variables(
         &mut self,
         names: &Vec<String>,
-        names_at: (usize, usize),
+        names_at: At,
         values: Bound<'_, PyAny>,
-        values_at: (usize, usize),
+        values_at: At,
         index: usize,
         template: TemplateString<'_>,
     ) -> Result<(), PyRenderError> {
@@ -392,7 +392,7 @@ fn resolve_python<'t>(value: Bound<'_, PyAny>, context: &Context) -> PyResult<Co
     )
 }
 
-fn resolve_bigint(bigint: BigInt, at: (usize, usize)) -> Result<usize, PyRenderError> {
+fn resolve_bigint(bigint: BigInt, at: At) -> Result<usize, PyRenderError> {
     match bigint.to_isize() {
         Some(n) => {
             let n = n.max(0);
@@ -476,7 +476,7 @@ impl<'t, 'py> Content<'t, 'py> {
     }
 
     /// Convert Content to usize, providing detailed errors if the conversion fails
-    pub fn resolve_usize(self, argument_at: (usize, usize)) -> Result<usize, PyRenderError> {
+    pub fn resolve_usize(self, argument_at: At) -> Result<usize, PyRenderError> {
         match self {
             Self::Int(n) => resolve_bigint(n, argument_at),
             Self::String(s) => match s.as_raw().parse::<BigInt>() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,25 +1,25 @@
 use num_bigint::BigInt;
 
-use dtl_lexer::types::Variable;
+use dtl_lexer::types::{At, Variable};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Text {
-    pub at: (usize, usize),
+    pub at: At,
 }
 
 impl Text {
-    pub fn new(at: (usize, usize)) -> Self {
+    pub fn new(at: At) -> Self {
         Self { at }
     }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TranslatedText {
-    pub at: (usize, usize),
+    pub at: At,
 }
 
 impl TranslatedText {
-    pub fn new(at: (usize, usize)) -> Self {
+    pub fn new(at: At) -> Self {
         Self { at }
     }
 }
@@ -36,7 +36,7 @@ pub enum ArgumentType {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Argument {
-    pub at: (usize, usize),
+    pub at: At,
     pub argument_type: ArgumentType,
 }
 


### PR DESCRIPTION
Rename to `lex_variable_or_filter` to better distinguish it from `lex_variable` which is used to lex the dotted lookup syntax for variables.

Return an `at` location from `lex_variable_or_filter` instead of only providing it for `VariableToken::Variable`. This is useful in #237 for error reporting in `{% include %}` tags.