### PR TITLE
Remove macos-13 from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,8 +122,6 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
-            target: x86_64
           - runner: macos-14
             target: aarch64
     steps:


### PR DESCRIPTION
The macOS-13 based runner images are retired.

https://github.com/actions/runner-images/issues/13046