### PR TITLE
Test Django test suite on stable/5.2.x branch

### DIFF
--- a/scripts/run_django_test_suite.py
+++ b/scripts/run_django_test_suite.py
@@ -96,6 +96,8 @@ def main():
                 "--depth",
                 "1",
                 "--no-tags",
+                "--branch",
+                "stable/5.2.x",
                 "https://github.com/django/django.git",
                 str(DJANGO_REPO_CACHE),
             ],


### PR DESCRIPTION
We're currently targeting Django 5.2.x, so this provides a stable reference point.