### PR TITLE
Fix parsing output of Django test suite when not capturing parsed output

### DIFF
--- a/scripts/run_django_test_suite.py
+++ b/scripts/run_django_test_suite.py
@@ -128,11 +128,11 @@ def main():
     )
     print(result.stderr, end="", file=sys.stderr)
 
-    summary, formatted_test_output = parse_test_output(result.stderr)
-    log(_format_passing_test_pct(summary))
-    log(_format_summary(summary))
-
     if args.parsed_output:
+        summary, formatted_test_output = parse_test_output(result.stderr)
+        log(_format_passing_test_pct(summary))
+        log(_format_summary(summary))
+
         Path(args.parsed_output).write_text(formatted_test_output)
         log(f"Parsed output written to {args.parsed_output}")
 


### PR DESCRIPTION
I was getting this error:

```python
$ python ./scripts/run_django_test_suite.py
Traceback (most recent call last):
  File "/home/lily/dev/django-rusty-templates/./scripts/run_django_test_suite.py", line 144, in <module>
    raise SystemExit(main())
                     ~~~~^^
  File "/home/lily/dev/django-rusty-templates/./scripts/run_django_test_suite.py", line 131, in main
    summary, formatted_test_output = parse_test_output(result.stderr)
                                     ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/home/lily/dev/django-rusty-templates/./scripts/run_django_test_suite.py", line 63, in parse_test_output
    for line in output.splitlines():
                ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'splitlines'
```