### PR TITLE
Fix some clippy lint errors from Rust 1.92

### DIFF
--- a/dtl-lexer/src/forloop.rs
+++ b/dtl-lexer/src/forloop.rs
@@ -1,3 +1,7 @@
+// Silence lint warnings for Miette Diagnostic
+// https://github.com/zkat/miette/issues/458
+// https://github.com/rust-lang/rust/issues/147648
+#![expect(unused_assignments)]
 use miette::{Diagnostic, SourceSpan};
 use thiserror::Error;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,7 @@
+// Silence lint warnings for Miette Diagnostic
+// https://github.com/zkat/miette/issues/458
+// https://github.com/rust-lang/rust/issues/147648
+#![expect(unused_assignments)]
 use miette::{Diagnostic, LabeledSpan, SourceSpan, miette};
 use pyo3::exceptions::PyKeyError;
 use pyo3::prelude::*;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,3 +1,7 @@
+// Silence lint warnings for Miette Diagnostic
+// https://github.com/zkat/miette/issues/458
+// https://github.com/rust-lang/rust/issues/147648
+#![expect(unused_assignments)]
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::iter::Peekable;


### PR DESCRIPTION
The rest appear to be caused by https://github.com/zkat/miette/issues/458.