### PR TITLE
Add MSRV = 1.92

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
+rust-version = "1.92"
 
 [workspace.dependencies]
 miette = { version = "7.6.0", features = ["fancy"] }

--- a/dtl-lexer/Cargo.toml
+++ b/dtl-lexer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dtl-lexer"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 miette.workspace = true


### PR DESCRIPTION
Fixes #260

I've set it to 1.92 since I've seen recent commits about clippy warning about 1.92.

At some point we might want to be a bit more lenient like [ruff](https://github.com/astral-sh/ruff/blob/main/docs/versioning.md#minimum-supported-rust-version) with their N-2 policy ?
