### PR TITLE
Add missing tests for `capfirst` builtin filter

### DIFF
--- a/tests/filters/test_capfirst.py
+++ b/tests/filters/test_capfirst.py
@@ -38,3 +38,24 @@ from django.utils.safestring import mark_safe
 )
 def test_capfirst(assert_render, template, context, expected):
     assert_render(template, context, expected)
+
+
+def test_capfirst_chained_with_bool(assert_render):
+    template = "{% for x in 'ab' %}{{ forloop.first|capfirst }}{% endfor %}"
+    assert_render(template=template, context={}, expected="TrueFalse")
+
+
+def test_capfirt_unexpected_argument(assert_parse_error):
+    rusty_message = """\
+  × capfirst filter does not take an argument
+   ╭────
+ 1 │ {{bob|capfirst:1}}
+   ·                ┬
+   ·                ╰── unexpected argument
+   ╰────
+"""
+    assert_parse_error(
+        template="{{bob|capfirst:1}}",
+        django_message="capfirst requires 1 arguments, 2 provided",
+        rusty_message=rusty_message,
+    )


### PR DESCRIPTION
I think there test for https://github.com/LilyFirefly/django-rusty-templates/blob/cc63cb68dd84cbd16ed0128df385199019c6df85/src/parse.rs#L133 was missing , i have added test for it.