### PR TITLE
Add helper function for generating rusty error messages

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,3 +19,30 @@ class BrokenDunderHtml(str):
 class BrokenDunderBool:
     def __bool__(self):
         1 / 0
+
+
+def get_rusty_error(template, header, target, sub_label="here"):
+    """
+    Automated Miette-style error generator.
+    """
+    offset = template.find(target)
+    if offset == -1:
+        offset = 0
+
+    width = len(target)
+
+    side_dashes_count = (width - 1) // 2
+    side_dashes = "─" * side_dashes_count
+    pointer = f"{side_dashes}┬{side_dashes}"
+
+    label_padding = " " * (offset + side_dashes_count)
+    padding = " " * offset
+
+    return f"""\
+  × {header}
+   ╭────
+ 1 │ {template}
+   · {padding}{pointer}
+   · {label_padding}╰── {sub_label}
+   ╰────
+"""


### PR DESCRIPTION
For me Currently, it's PITA to write Rust error messages. To do so, I first have to run pytest, check the format of the error, and then copy-paste the message. Even though I’ve fixed the indentation multiple times, it still doesn’t work as expected.

So, I’ve added a helper function to fix this.