### PR TITLE
chore(django-dtl): move the empty tag case into django-dtl

### DIFF
--- a/dtl-lexer/src/tag.rs
+++ b/dtl-lexer/src/tag.rs
@@ -6,13 +6,12 @@ pub mod include;
 pub mod load;
 pub mod lorem;
 
+use crate::common::NextChar;
+use crate::types::{At, TemplateString};
+use crate::{END_TAG_LEN, START_TAG_LEN, TemplateContent};
 use miette::{Diagnostic, SourceSpan};
 use thiserror::Error;
 use unicode_xid::UnicodeXID;
-
-use crate::TemplateContent;
-use crate::common::NextChar;
-use crate::types::{At, TemplateString};
 
 #[derive(Error, Debug, Diagnostic, Eq, PartialEq)]
 pub enum TagLexerError {
@@ -21,17 +20,11 @@ pub enum TagLexerError {
         #[label("here")]
         at: SourceSpan,
     },
-}
-
-#[derive(Debug, PartialEq)]
-pub struct TagToken {
-    pub at: At,
-}
-
-impl<'t> TemplateContent<'t> for TagToken {
-    fn content(&self, template: TemplateString<'t>) -> &'t str {
-        template.content(self.at)
-    }
+    #[error("Empty block tag")]
+    EmptyTag {
+        #[label("here")]
+        at: SourceSpan,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -45,21 +38,38 @@ impl<'t> TemplateContent<'t> for TagParts {
     }
 }
 
-pub fn lex_tag(tag: &str, start: usize) -> Result<Option<(TagToken, TagParts)>, TagLexerError> {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Tag {
+    pub at: At,
+    pub parts: TagParts,
+}
+
+impl<'t> TemplateContent<'t> for Tag {
+    fn content(&self, template: TemplateString<'t>) -> &'t str {
+        template.content(self.at)
+    }
+}
+
+pub fn lex_tag(tag: &str, start: usize) -> Result<Tag, TagLexerError> {
     let rest = tag.trim_start();
     if rest.trim().is_empty() {
-        return Ok(None);
+        return Err(TagLexerError::EmptyTag {
+            at: (
+                start - START_TAG_LEN,
+                START_TAG_LEN + tag.len() + END_TAG_LEN,
+            )
+                .into(),
+        });
     }
 
     let start = start + tag.len() - rest.len();
     let tag = tag.trim();
     let Some(tag_len) = tag.find(|c: char| !c.is_xid_continue()) else {
         let at = (start, tag.len());
-        let token = TagToken { at };
         let parts = TagParts {
             at: (start + tag.len(), 0),
         };
-        return Ok(Some((token, parts)));
+        return Ok(Tag { at, parts });
     };
     let index = tag.next_whitespace();
     if index > tag_len {
@@ -67,20 +77,20 @@ pub fn lex_tag(tag: &str, start: usize) -> Result<Option<(TagToken, TagParts)>, 
         return Err(TagLexerError::InvalidTagName { at: at.into() });
     }
     let at = (start, tag_len);
-    let token = TagToken { at };
     let rest = &tag[tag_len..];
     let trimmed = rest.trim();
     let start = start + tag_len + rest.len() - trimmed.len();
-    let at = (start, trimmed.len());
-    let parts = TagParts { at };
-    Ok(Some((token, parts)))
+    let parts = TagParts {
+        at: (start, trimmed.len()),
+    };
+    Ok(Tag { at, parts })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use crate::types::{IntoTemplateString, TemplateString};
+    use crate::types::IntoTemplateString;
     use crate::{END_TAG_LEN, START_TAG_LEN};
 
     fn trim_tag(template: &str) -> &str {
@@ -91,17 +101,18 @@ mod tests {
     fn test_lex_empty() {
         let template = "{%  %}";
         let tag = trim_tag(template);
-        assert!(lex_tag(tag, START_TAG_LEN).unwrap().is_none());
+        let error = lex_tag(tag, START_TAG_LEN).unwrap_err();
+        assert_eq!(error, TagLexerError::EmptyTag { at: (0, 6).into() })
     }
 
     #[test]
     fn test_lex_tag() {
         let template = "{% csrftoken %}";
         let tag = trim_tag(template);
-        let (token, rest) = lex_tag(tag, START_TAG_LEN).unwrap().unwrap();
-        assert_eq!(token, TagToken { at: (3, 9) });
-        assert_eq!(TemplateString(template).content(token.at), "csrftoken");
-        assert_eq!(rest, TagParts { at: (12, 0) })
+        let tag = lex_tag(tag, START_TAG_LEN).unwrap();
+        assert_eq!(tag.at, (3, 9));
+        assert_eq!(tag.content(template.into_template_string()), "csrftoken");
+        assert_eq!(tag.parts, TagParts { at: (12, 0) })
     }
 
     #[test]
@@ -124,26 +135,26 @@ mod tests {
     fn test_lex_tag_rest() {
         let template = "{% url name arg %}";
         let tag = trim_tag(template);
-        let (token, rest) = lex_tag(tag, START_TAG_LEN).unwrap().unwrap();
-        assert_eq!(token, TagToken { at: (3, 3) });
-        assert_eq!(TemplateString(template).content(token.at), "url");
-        assert_eq!(rest, TagParts { at: (7, 8) })
+        let tag = lex_tag(tag, START_TAG_LEN).unwrap();
+        assert_eq!(tag.at, (3, 3));
+        assert_eq!(tag.content(template.into_template_string()), "url");
+        assert_eq!(tag.parts, TagParts { at: (7, 8) })
     }
 
     #[test]
     fn test_template_content_impl() {
         let template = "{% url name arg %}";
         let template_string = "{% url name arg %}".into_template_string();
-        let (token, rest) = lex_tag(trim_tag(template), START_TAG_LEN).unwrap().unwrap();
-        assert_eq!(template_string.content(token.at), "url");
+        let tag = lex_tag(trim_tag(template), START_TAG_LEN).unwrap();
+        assert_eq!(tag.content(template.into_template_string()), "url");
         assert_eq!(
-            template_string.content(token.at),
-            token.content(template_string)
+            template_string.content(tag.at),
+            tag.content(template_string)
         );
-        assert_eq!(template_string.content(rest.at), "name arg");
+        assert_eq!(tag.parts.content(template_string), "name arg");
         assert_eq!(
-            template_string.content(rest.at),
-            rest.content(template_string)
+            template_string.content(tag.parts.at),
+            tag.parts.content(template_string)
         );
     }
 }


### PR DESCRIPTION
This continues what I started in #272. This simply move the empty tag case in `django-dtl`.