### PR TITLE
Pin to Django 5.2.x for development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ DJANGO_SETTINGS_MODULE = "tests.settings"
 
 [dependency-groups]
 dev = [
-    "django",
+    "django~=5.2.9",
     "hypothesis",
     "maturin",
     "pytest",


### PR DESCRIPTION
We're currently targetting Django 5.2, so it's really helpful to avoid installing Django 6.0 or later during development.

This stays a development dependency because when we release we want to allow users the flexibility of mixing and matching versions of Django and Django Rusty Templates as is convenient. For example, upgrading DRT before Django to opt into new functionality, or to stagger the upgrade process.