### PR TITLE
Typos ignored intentionally in src/render/lorem.rs and test_if.py

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ cargo-llvm-cov = "0.6.18"
 [package.metadata.cargo-shear]
 ignored = ["cargo-llvm-cov"]
 
+[workspace.metadata.typos]
+[workspace.metadata.typos.files]
+extend-exclude = ["src/render/lorem.rs", "test_if.py"]
+
 [workspace.lints.clippy]
 # See https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html
 pedantic = { level = "deny", priority = -1 }


### PR DESCRIPTION
as mention https://github.com/LilyFirefly/django-rusty-templates/pull/276#discussion_r2656499294  the pre commit hook auto correcting typos But those typos were intentionals. 

when i was configuring` typos (tool)` in `Cargo.toml `, `test_if.py `get flagged due to typo `"Nd"` which get autocorrected to `"And"`.

Refs:
- https://github.com/crate-ci/typos/blob/master/docs/reference.md 