### PR TITLE
Fix an edge-case in {% lorem %}

### DIFF
--- a/src/render/tags.rs
+++ b/src/render/tags.rs
@@ -681,10 +681,12 @@ impl Render for Tag {
 
                 let text = match lorem.method {
                     LoremMethod::Words => {
-                        let final_count = if val < 0 {
-                            (COMMON_WORDS.len() as i64 + val).max(0) as usize
-                        } else {
-                            val as usize
+                        let final_count = match (val, lorem.common) {
+                            (val, true) if val < 0 => {
+                                (COMMON_WORDS.len() as i64 + val).max(0) as usize
+                            }
+                            (val, false) if val < 0 => 0,
+                            (val, _) => val as usize,
                         };
                         words(final_count, lorem.common)
                     }

--- a/tests/tags/test_lorem.py
+++ b/tests/tags/test_lorem.py
@@ -448,6 +448,12 @@ def test_lorem_words_with_negative_count(render_output):
     assert output == " ".join(COMMON_WORDS[:-5])
 
 
+def test_lorem_words_with_negative_count_random(render_output):
+    template = "{% lorem -5 w random %}"
+    output = render_output(template=template, context={})
+    assert output == ""
+
+
 def test_lorem_render_error(assert_render_error):
     template = "{% lorem count %}"
     context = {"count": lambda: 1 / 0}


### PR DESCRIPTION
Calling `{% lorem -5 w random %}` doesn't display the same negative indexing/slicing behaviour that `{% lorem -5 w %}` does, so we need to handle this case slightly differently.