### PR TITLE
Replace --export-prefix with --sh for cargo llvm-cov

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Install Django Rusty Templates
       run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
+        cargo llvm-cov show-env --sh > llvm-cov-env.sh
         source llvm-cov-env.sh
         uv run maturin develop
 
@@ -82,13 +82,13 @@ jobs:
 
     - name: Test with pytest
       run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
+        cargo llvm-cov show-env --sh > llvm-cov-env.sh
         source llvm-cov-env.sh
         uv run pytest --cov --cov-report=xml
 
     - name: Get rust coverage report
       run: |
-        cargo llvm-cov show-env --export-prefix > llvm-cov-env.sh
+        cargo llvm-cov show-env --sh > llvm-cov-env.sh
         source llvm-cov-env.sh
         cargo llvm-cov report --codecov --output-path codecov.json
 

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ python-coverage:
 rust-coverage:
     #!/usr/bin/bash
     cargo llvm-cov clean --workspace
-    source <(cargo llvm-cov show-env --export-prefix)
+    source <(cargo llvm-cov show-env --sh)
     cargo llvm-cov --no-report
     maturin develop
     pytest
@@ -14,7 +14,7 @@ rust-coverage:
 rust-coverage-browser:
     #!/usr/bin/bash
     cargo llvm-cov clean --workspace
-    source <(cargo llvm-cov show-env --export-prefix)
+    source <(cargo llvm-cov show-env --sh)
     cargo llvm-cov --no-report
     maturin develop
     pytest


### PR DESCRIPTION
`--export-prefix` has been renamed to `--sh` and is now deprecated.