### PR TITLE
Include dtl-lexer in python coverage report

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -90,7 +90,7 @@ jobs:
       run: |
         cargo llvm-cov show-env --sh > llvm-cov-env.sh
         source llvm-cov-env.sh
-        cargo llvm-cov report --codecov --output-path codecov.json
+        cargo llvm-cov report -p dtl-lexer -p django-rusty-templates --codecov --output-path codecov.json
 
     - name: Upload to codecov
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2


### PR DESCRIPTION
When running `cargo llvm-cov `report from the root of a workspace, it defaults to collecting coverage only for the root package `(django-rusty-templates).` Since `dtl-lexer` is a separate crate within the workspace, its coverage data was generated during tests but simply ignored when generating the final report.

- Explicitly include `dtl-lexer` and `django-rusty-templates` packages in `cargo llvm-cov report` command

closes #340 
