### PR TITLE
Ignored whitespace before commas in variable names in forloop

### DIFF
--- a/dtl-lexer/src/tag/forloop.rs
+++ b/dtl-lexer/src/tag/forloop.rs
@@ -244,6 +244,11 @@ impl<'t> ForLexer<'t> {
             State::Done => return None,
         }
 
+        let first_non_ws_index = self.rest.next_non_whitespace();
+        if self.rest[first_non_ws_index..].starts_with(',') {
+            let at = (self.byte + first_non_ws_index, 1);
+            return Some(Err(ForLexerError::UnexpectedComma { at: at.into() }));
+        }
         let index = self.rest.next_whitespace();
         let (index, next_index) = match self.rest.find(',') {
             Some(comma_index) if comma_index < index => {

--- a/dtl-lexer/src/tag/forloop.rs
+++ b/dtl-lexer/src/tag/forloop.rs
@@ -236,21 +236,18 @@ impl<'t> ForLexer<'t> {
 
     fn get_index_and_next_index(&mut self, index: usize) -> Result<(usize, usize), ForLexerError> {
         let (index, next_index) = match self.rest.find(',') {
+            Some(0) => {
+                let at = (self.byte, 1);
+                return Err(ForLexerError::UnexpectedComma { at: at.into() });
+            }
             Some(comma_index) if comma_index < index => {
                 let next_index = self.rest[comma_index + 1..].next_non_whitespace();
-                let after_comma = comma_index + 1 + next_index;
-                if after_comma < self.rest.len() && self.rest[after_comma..].starts_with(',') {
-                    let at = (self.byte + after_comma, 1);
-                    return Err(ForLexerError::UnexpectedExpression { at: at.into() });
-                }
                 (comma_index, comma_index + 1 + next_index)
             }
             _ => {
                 let whitespace_to_next = self.rest[index..].next_non_whitespace();
                 let after_whitespace = index + whitespace_to_next;
-                if after_whitespace < self.rest.len()
-                    && self.rest[after_whitespace..].starts_with(',')
-                {
+                if self.rest[after_whitespace..].starts_with(',') {
                     let next_index = self.rest[after_whitespace + 1..].next_non_whitespace();
                     let after_comma = after_whitespace + 1 + next_index;
                     if after_comma < self.rest.len() && self.rest[after_comma..].starts_with(',') {
@@ -299,11 +296,6 @@ impl<'t> ForLexer<'t> {
             State::Done => return None,
         }
 
-        let first_non_ws_index = self.rest.next_non_whitespace();
-        if self.rest[first_non_ws_index..].starts_with(',') {
-            let at = (self.byte + first_non_ws_index, 1);
-            return Some(Err(ForLexerError::UnexpectedComma { at: at.into() }));
-        }
         let index = self.rest.next_whitespace();
         let (index, next_index) = match self.get_index_and_next_index(index) {
             Ok(indexes) => indexes,

--- a/dtl-lexer/src/tag/forloop.rs
+++ b/dtl-lexer/src/tag/forloop.rs
@@ -268,6 +268,27 @@ impl<'t> ForLexer<'t> {
         Ok((index, next_index))
     }
 
+    fn check_invalid_variable_name(&mut self, index: usize, at: At) -> Result<(), ForLexerError> {
+        let name = &self.rest[..index];
+
+        let (_, _, remainder) = lex_variable(0, name);
+        if !remainder.is_empty() {
+            return Err(ForLexerError::InvalidName {
+                name: name.to_string(),
+                at: at.into(),
+            });
+        }
+
+        if name == '.'.to_string() || name.contains(['"', '\'', '|']) {
+            return Err(ForLexerError::InvalidName {
+                name: name.to_string(),
+                at: at.into(),
+            });
+        }
+
+        Ok(())
+    }
+
     pub fn lex_variable_name(&mut self) -> Option<Result<ForVariableNameToken, ForLexerError>> {
         match self.state {
             State::VariableName if !self.rest.is_empty() => {}
@@ -290,25 +311,13 @@ impl<'t> ForLexer<'t> {
         };
         let at = (self.byte, index);
         self.previous_at = Some(at);
-        let name = &self.rest[..index];
 
-        if name == ';'.to_string() || name == '.'.to_string() {
+        if let Err(err) = self.check_invalid_variable_name(index, at) {
             self.rest = "";
             self.state = State::Done;
-            return Some(Err(ForLexerError::InvalidName {
-                name: name.to_string(),
-                at: at.into(),
-            }));
+            return Some(Err(err));
         }
 
-        if name.contains(['"', '\'', '|']) {
-            self.rest = "";
-            self.state = State::Done;
-            return Some(Err(ForLexerError::InvalidName {
-                name: name.to_string(),
-                at: at.into(),
-            }));
-        }
         self.byte += next_index;
         self.rest = &self.rest[next_index..];
         Some(Ok(ForVariableNameToken { at }))

--- a/dtl-lexer/src/tag/forloop.rs
+++ b/dtl-lexer/src/tag/forloop.rs
@@ -234,31 +234,6 @@ impl<'t> ForLexer<'t> {
         Err(ForLexerError::UnexpectedExpression { at: at.into() })
     }
 
-    fn get_index_and_next_index(&mut self, index: usize) -> Result<(usize, usize), ForLexerError> {
-        let (index, next_index) = match self.rest.find(',') {
-            Some(0) => {
-                let at = (self.byte, 1);
-                return Err(ForLexerError::UnexpectedComma { at: at.into() });
-            }
-            Some(comma_index) if comma_index < index => {
-                let next_index = self.rest[comma_index + 1..].next_non_whitespace();
-                (comma_index, comma_index + 1 + next_index)
-            }
-            _ => {
-                let after_whitespace = index + self.rest[index..].next_non_whitespace();
-                if self.rest[after_whitespace..].starts_with(',') {
-                    let next_index = self.rest[after_whitespace + 1..].next_non_whitespace();
-                    (index, after_whitespace + 1 + next_index)
-                } else {
-                    self.state = State::Done;
-                    (index, after_whitespace)
-                }
-            }
-        };
-
-        Ok((index, next_index))
-    }
-
     fn check_invalid_variable_name(&mut self, index: usize, at: At) -> Result<(), ForLexerError> {
         let name = &self.rest[..index];
 
@@ -291,9 +266,25 @@ impl<'t> ForLexer<'t> {
         }
 
         let index = self.rest.next_whitespace();
-        let (index, next_index) = match self.get_index_and_next_index(index) {
-            Ok(indexes) => indexes,
-            Err(e) => return Some(Err(e)),
+        let (index, next_index) = match self.rest.find(',') {
+            Some(0) => {
+                let at = (self.byte, 1);
+                return Some(Err(ForLexerError::UnexpectedComma { at: at.into() }));
+            }
+            Some(comma_index) if comma_index < index => {
+                let next_index = self.rest[comma_index + 1..].next_non_whitespace();
+                (comma_index, comma_index + 1 + next_index)
+            }
+            _ => {
+                let after_whitespace = index + self.rest[index..].next_non_whitespace();
+                if self.rest[after_whitespace..].starts_with(',') {
+                    let next_index = self.rest[after_whitespace + 1..].next_non_whitespace();
+                    (index, after_whitespace + 1 + next_index)
+                } else {
+                    self.state = State::Done;
+                    (index, after_whitespace)
+                }
+            }
         };
         let at = (self.byte, index);
         self.previous_at = Some(at);

--- a/dtl-lexer/src/tag/forloop.rs
+++ b/dtl-lexer/src/tag/forloop.rs
@@ -241,12 +241,20 @@ impl<'t> ForLexer<'t> {
         let (index, next_index) = match self.rest.find(',') {
             Some(comma_index) if comma_index < index => {
                 let next_index = self.rest[comma_index + 1..].next_non_whitespace();
-                (comma_index, next_index + 1)
+                (comma_index, comma_index + 1 + next_index)
             }
             _ => {
-                self.state = State::Done;
-                let next_index = self.rest[index..].next_non_whitespace();
-                (index, next_index)
+                let whitespace_to_next = self.rest[index..].next_non_whitespace();
+                let after_whitespace = index + whitespace_to_next;
+                if after_whitespace < self.rest.len()
+                    && self.rest[after_whitespace..].starts_with(',')
+                {
+                    let next_index = self.rest[after_whitespace + 1..].next_non_whitespace();
+                    (index, after_whitespace + 1 + next_index)
+                } else {
+                    self.state = State::Done;
+                    (index, index + whitespace_to_next)
+                }
             }
         };
         let at = (self.byte, index);
@@ -260,8 +268,8 @@ impl<'t> ForLexer<'t> {
                 at: at.into(),
             }));
         }
-        self.byte += index + next_index;
-        self.rest = &self.rest[index + next_index..];
+        self.byte += next_index;
+        self.rest = &self.rest[next_index..];
         Some(Ok(ForVariableNameToken { at }))
     }
 }

--- a/dtl-lexer/src/tag/forloop.rs
+++ b/dtl-lexer/src/tag/forloop.rs
@@ -234,6 +234,40 @@ impl<'t> ForLexer<'t> {
         Err(ForLexerError::UnexpectedExpression { at: at.into() })
     }
 
+    fn get_index_and_next_index(&mut self, index: usize) -> Result<(usize, usize), ForLexerError> {
+        let (index, next_index) = match self.rest.find(',') {
+            Some(comma_index) if comma_index < index => {
+                let next_index = self.rest[comma_index + 1..].next_non_whitespace();
+                let after_comma = comma_index + 1 + next_index;
+                if after_comma < self.rest.len() && self.rest[after_comma..].starts_with(',') {
+                    let at = (self.byte + after_comma, 1);
+                    return Err(ForLexerError::UnexpectedExpression { at: at.into() });
+                }
+                (comma_index, comma_index + 1 + next_index)
+            }
+            _ => {
+                let whitespace_to_next = self.rest[index..].next_non_whitespace();
+                let after_whitespace = index + whitespace_to_next;
+                if after_whitespace < self.rest.len()
+                    && self.rest[after_whitespace..].starts_with(',')
+                {
+                    let next_index = self.rest[after_whitespace + 1..].next_non_whitespace();
+                    let after_comma = after_whitespace + 1 + next_index;
+                    if after_comma < self.rest.len() && self.rest[after_comma..].starts_with(',') {
+                        let at = (self.byte + after_comma, 1);
+                        return Err(ForLexerError::UnexpectedComma { at: at.into() });
+                    }
+                    (index, after_whitespace + 1 + next_index)
+                } else {
+                    self.state = State::Done;
+                    (index, index + whitespace_to_next)
+                }
+            }
+        };
+
+        Ok((index, next_index))
+    }
+
     pub fn lex_variable_name(&mut self) -> Option<Result<ForVariableNameToken, ForLexerError>> {
         match self.state {
             State::VariableName if !self.rest.is_empty() => {}
@@ -250,34 +284,9 @@ impl<'t> ForLexer<'t> {
             return Some(Err(ForLexerError::UnexpectedComma { at: at.into() }));
         }
         let index = self.rest.next_whitespace();
-        let (index, next_index) = match self.rest.find(',') {
-            Some(comma_index) if comma_index < index => {
-                let next_index = self.rest[comma_index + 1..].next_non_whitespace();
-                let after_comma = comma_index + 1 + next_index;
-                if after_comma < self.rest.len() && self.rest[after_comma..].starts_with(',') {
-                    let at = (self.byte + after_comma, 1);
-                    return Some(Err(ForLexerError::UnexpectedExpression { at: at.into() }));
-                }
-                (comma_index, comma_index + 1 + next_index)
-            }
-            _ => {
-                let whitespace_to_next = self.rest[index..].next_non_whitespace();
-                let after_whitespace = index + whitespace_to_next;
-                if after_whitespace < self.rest.len()
-                    && self.rest[after_whitespace..].starts_with(',')
-                {
-                    let next_index = self.rest[after_whitespace + 1..].next_non_whitespace();
-                    let after_comma = after_whitespace + 1 + next_index;
-                    if after_comma < self.rest.len() && self.rest[after_comma..].starts_with(',') {
-                        let at = (self.byte + after_comma, 1);
-                        return Some(Err(ForLexerError::UnexpectedComma { at: at.into() }));
-                    }
-                    (index, after_whitespace + 1 + next_index)
-                } else {
-                    self.state = State::Done;
-                    (index, index + whitespace_to_next)
-                }
-            }
+        let (index, next_index) = match self.get_index_and_next_index(index) {
+            Ok(indexes) => indexes,
+            Err(e) => return Some(Err(e)),
         };
         let at = (self.byte, index);
         self.previous_at = Some(at);

--- a/dtl-lexer/src/tag/forloop.rs
+++ b/dtl-lexer/src/tag/forloop.rs
@@ -29,6 +29,12 @@ pub enum ForLexerError {
         #[label("unexpected expression")]
         at: SourceSpan,
     },
+    #[error("Unexpected comma in for loop:")]
+    #[diagnostic(help("Try removing the comma, or adding a variable name before it"))]
+    UnexpectedComma {
+        #[label("here")]
+        at: SourceSpan,
+    },
 }
 
 #[derive(Clone, Error, Debug, Diagnostic, PartialEq, Eq)]
@@ -259,7 +265,7 @@ impl<'t> ForLexer<'t> {
                     let after_comma = after_whitespace + 1 + next_index;
                     if after_comma < self.rest.len() && self.rest[after_comma..].starts_with(',') {
                         let at = (self.byte + after_comma, 1);
-                        return Some(Err(ForLexerError::UnexpectedExpression { at: at.into() }));
+                        return Some(Err(ForLexerError::UnexpectedComma { at: at.into() }));
                     }
                     (index, after_whitespace + 1 + next_index)
                 } else {

--- a/dtl-lexer/src/tag/forloop.rs
+++ b/dtl-lexer/src/tag/forloop.rs
@@ -245,14 +245,13 @@ impl<'t> ForLexer<'t> {
                 (comma_index, comma_index + 1 + next_index)
             }
             _ => {
-                let whitespace_to_next = self.rest[index..].next_non_whitespace();
-                let after_whitespace = index + whitespace_to_next;
+                let after_whitespace = index + self.rest[index..].next_non_whitespace();
                 if self.rest[after_whitespace..].starts_with(',') {
                     let next_index = self.rest[after_whitespace + 1..].next_non_whitespace();
                     (index, after_whitespace + 1 + next_index)
                 } else {
                     self.state = State::Done;
-                    (index, index + whitespace_to_next)
+                    (index, after_whitespace)
                 }
             }
         };

--- a/dtl-lexer/src/tag/forloop.rs
+++ b/dtl-lexer/src/tag/forloop.rs
@@ -282,6 +282,16 @@ impl<'t> ForLexer<'t> {
         let at = (self.byte, index);
         self.previous_at = Some(at);
         let name = &self.rest[..index];
+
+        if name == ';'.to_string() || name == '.'.to_string() {
+            self.rest = "";
+            self.state = State::Done;
+            return Some(Err(ForLexerError::InvalidName {
+                name: name.to_string(),
+                at: at.into(),
+            }));
+        }
+
         if name.contains(['"', '\'', '|']) {
             self.rest = "";
             self.state = State::Done;

--- a/dtl-lexer/src/tag/forloop.rs
+++ b/dtl-lexer/src/tag/forloop.rs
@@ -249,11 +249,6 @@ impl<'t> ForLexer<'t> {
                 let after_whitespace = index + whitespace_to_next;
                 if self.rest[after_whitespace..].starts_with(',') {
                     let next_index = self.rest[after_whitespace + 1..].next_non_whitespace();
-                    let after_comma = after_whitespace + 1 + next_index;
-                    if after_comma < self.rest.len() && self.rest[after_comma..].starts_with(',') {
-                        let at = (self.byte + after_comma, 1);
-                        return Err(ForLexerError::UnexpectedComma { at: at.into() });
-                    }
                     (index, after_whitespace + 1 + next_index)
                 } else {
                     self.state = State::Done;

--- a/dtl-lexer/src/tag/forloop.rs
+++ b/dtl-lexer/src/tag/forloop.rs
@@ -237,10 +237,16 @@ impl<'t> ForLexer<'t> {
             }
             State::Done => return None,
         }
+
         let index = self.rest.next_whitespace();
         let (index, next_index) = match self.rest.find(',') {
             Some(comma_index) if comma_index < index => {
                 let next_index = self.rest[comma_index + 1..].next_non_whitespace();
+                let after_comma = comma_index + 1 + next_index;
+                if after_comma < self.rest.len() && self.rest[after_comma..].starts_with(',') {
+                    let at = (self.byte + after_comma, 1);
+                    return Some(Err(ForLexerError::UnexpectedExpression { at: at.into() }));
+                }
                 (comma_index, comma_index + 1 + next_index)
             }
             _ => {
@@ -250,6 +256,11 @@ impl<'t> ForLexer<'t> {
                     && self.rest[after_whitespace..].starts_with(',')
                 {
                     let next_index = self.rest[after_whitespace + 1..].next_non_whitespace();
+                    let after_comma = after_whitespace + 1 + next_index;
+                    if after_comma < self.rest.len() && self.rest[after_comma..].starts_with(',') {
+                        let at = (self.byte + after_comma, 1);
+                        return Some(Err(ForLexerError::UnexpectedExpression { at: at.into() }));
+                    }
                     (index, after_whitespace + 1 + next_index)
                 } else {
                     self.state = State::Done;

--- a/tests/tags/test_for.py
+++ b/tests/tags/test_for.py
@@ -950,11 +950,47 @@ def test_for_tag_unexpected_token_after_comma(assert_parse_error):
         "'for' tag received an invalid argument: for key , ; value in items"
     )
     rusty_message = snapshot("""\
-  × Unexpected expression in for loop. Did you miss a comma when unpacking?
+  × Invalid variable name ; in for loop:
    ╭────
  1 │ {% for key , ; value in items %}{{ key }}:{{ value }}/{% endfor %}
-   ·                ──┬──
-   ·                  ╰── unexpected expression
+   ·              ┬
+   ·              ╰── invalid variable name
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_invalid_variable_names(assert_parse_error):
+    template = "{% for key , . value in items %}{{ key }}:{{ value }}/{% endfor %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for key , . value in items"
+    )
+    rusty_message = snapshot("""\
+  × Invalid variable name . in for loop:
+   ╭────
+ 1 │ {% for key , . value in items %}{{ key }}:{{ value }}/{% endfor %}
+   ·              ┬
+   ·              ╰── invalid variable name
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_invalid_variable_names_02(assert_parse_error):
+    template = "{% for key , . value in items %}{{ key }}:{{ value }}/{% endfor %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for key , . value in items"
+    )
+    rusty_message = snapshot("""\
+  × Invalid variable name . in for loop:
+   ╭────
+ 1 │ {% for key , . value in items %}{{ key }}:{{ value }}/{% endfor %}
+   ·              ┬
+   ·              ╰── invalid variable name
    ╰────
 """)
     assert_parse_error(

--- a/tests/tags/test_for.py
+++ b/tests/tags/test_for.py
@@ -981,14 +981,14 @@ def test_for_tag_invalid_variable_names(assert_parse_error):
 
 
 def test_for_tag_invalid_variable_names_02(assert_parse_error):
-    template = "{% for key , . value in items %}{{ key }}:{{ value }}/{% endfor %}"
+    template = "{% for key , # value in items %}{{ key }}:{{ value }}/{% endfor %}"
     django_message = snapshot(
-        "'for' tag received an invalid argument: for key , . value in items"
+        "'for' tag received an invalid argument: for key , # value in items"
     )
     rusty_message = snapshot("""\
-  × Invalid variable name . in for loop:
+  × Invalid variable name # in for loop:
    ╭────
- 1 │ {% for key , . value in items %}{{ key }}:{{ value }}/{% endfor %}
+ 1 │ {% for key , # value in items %}{{ key }}:{{ value }}/{% endfor %}
    ·              ┬
    ·              ╰── invalid variable name
    ╰────
@@ -1045,6 +1045,160 @@ def test_for_tag_invalid_variable_names_05(assert_parse_error):
  1 │ {% for key , & value in items %}{{ key }}:{{ value }}/{% endfor %}
    ·              ┬
    ·              ╰── invalid variable name
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_invalid_variable_name_with_symbols_in_unpack(assert_parse_error):
+    template = "{% for ab;%t$s in items %}{{ ab;%t$s }}{% endfor %}"
+    django_message = snapshot("Could not parse the remainder: ';%t$s' from 'ab;%t$s'")
+    rusty_message = snapshot("""\
+  × Invalid variable name ab;%t$s in for loop:
+   ╭────
+ 1 │ {% for ab;%t$s in items %}{{ ab;%t$s }}{% endfor %}
+   ·        ───┬───
+   ·           ╰── invalid variable name
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_variable_name_with_dot_in_unpack(assert_render):
+    template = "{% for foo.bar in items %}{{ foo.bar }}{% endfor %}"
+    context = {"items": ["django", "rusty", "templates"]}
+    expected = ""
+    assert_render(template=template, context=context, expected=expected)
+
+
+def test_for_tag_variable_name_with_semicolon_in_unpack(assert_parse_error):
+    template = "{% for foo;bar in items %}{{ foo;bar }}{% endfor %}"
+    django_message = snapshot("Could not parse the remainder: ';bar' from 'foo;bar'")
+    rusty_message = snapshot("""\
+  × Invalid variable name foo;bar in for loop:
+   ╭────
+ 1 │ {% for foo;bar in items %}{{ foo;bar }}{% endfor %}
+   ·        ───┬───
+   ·           ╰── invalid variable name
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_variable_name_with_dollar_in_unpack(assert_parse_error):
+    template = "{% for foo$@$;%t$$bar in items %}{{ foo$@$;%t$$bar }}{% endfor %}"
+    django_message = snapshot(
+        "Could not parse the remainder: '$@$;%t$$bar' from 'foo$@$;%t$$bar'"
+    )
+    rusty_message = snapshot("""\
+  × Invalid variable name foo$@$;%t$$bar in for loop:
+   ╭────
+ 1 │ {% for foo$@$;%t$$bar in items %}{{ foo$@$;%t$$bar }}{% endfor %}
+   ·        ───────┬──────
+   ·               ╰── invalid variable name
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_variable_with_random_tokens_in_the_middle_in_unpack_01(
+    assert_parse_error,
+):
+    template = "{% for foo%%%%###$$$bar in items %}{{ foo%%%%###$$$bar }}{% endfor %}"
+    django_message = snapshot(
+        "Could not parse the remainder: '%%%%###$$$bar' from 'foo%%%%###$$$bar'"
+    )
+    rusty_message = snapshot("""\
+  × Invalid variable name foo%%%%###$$$bar in for loop:
+   ╭────
+ 1 │ {% for foo%%%%###$$$bar in items %}{{ foo%%%%###$$$bar }}{% endfor %}
+   ·        ────────┬───────
+   ·                ╰── invalid variable name
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_variable_with_random_tokens_in_the_middle_in_unpack_02(
+    assert_parse_error,
+):
+    template = "{% for foo$&&&&&&&$$bar in items %}{{ foo$&&&&&&&$$bar }}{% endfor %}"
+    django_message = snapshot(
+        "Could not parse the remainder: '$&&&&&&&$$bar' from 'foo$&&&&&&&$$bar'"
+    )
+    rusty_message = snapshot("""\
+  × Invalid variable name foo$&&&&&&&$$bar in for loop:
+   ╭────
+ 1 │ {% for foo$&&&&&&&$$bar in items %}{{ foo$&&&&&&&$$bar }}{% endfor %}
+   ·        ────────┬───────
+   ·                ╰── invalid variable name
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_variable_with_random_tokens_in_the_middle_in_unpack_03(
+    assert_parse_error,
+):
+    template = "{% for foo$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$bar in items %}{{ foo$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$bar }}{% endfor %}"
+    django_message = snapshot(
+        "Could not parse the remainder: '$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$bar' from 'foo$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$bar'"
+    )
+    rusty_message = snapshot("""\
+  × Invalid variable name foo$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$bar in for
+  │ loop:
+   ╭────
+ 1 │ {% for foo$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$bar in items %}{{ foo$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$bar }}{% endfor %}
+   ·        ─────────────────────┬────────────────────
+   ·                             ╰── invalid variable name
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_invalid_variable_name_with_filter_in_unpack(assert_parse_error):
+    template = "{% for foo|upper in items %}{{ foo|upper }}{% endfor %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for foo|upper in items"
+    )
+    rusty_message = snapshot("""\
+  × Invalid variable name foo|upper in for loop:
+   ╭────
+ 1 │ {% for foo|upper in items %}{{ foo|upper }}{% endfor %}
+   ·        ────┬────
+   ·            ╰── invalid variable name
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_invalid_variable_name_with_filter_arg_in_unpack(assert_parse_error):
+    template = '{% for foo|default:"bar" in items %}{{ foo|default:"bar" }}{% endfor %}'
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for foo|default:\"bar\" in items"
+    )
+    rusty_message = snapshot("""\
+  × Invalid variable name foo|default:"bar" in for loop:
+   ╭────
+ 1 │ {% for foo|default:"bar" in items %}{{ foo|default:"bar" }}{% endfor %}
+   ·        ────────┬────────
+   ·                ╰── invalid variable name
    ╰────
 """)
     assert_parse_error(

--- a/tests/tags/test_for.py
+++ b/tests/tags/test_for.py
@@ -797,15 +797,29 @@ def test_missing_argument_after_for_loop(assert_render_error):
     )
 
 
-def test_for_tag_unpack04(assert_render):
+def test_for_tag_with_two_variable_names_with_whitespace(assert_render):
     template = "{% for key , value in items %}{{ key }}:{{ value }}/{% endfor %}"
     context = {"items": (("one", 1), ("two", 2))}
     expected = "one:1/two:2/"
     assert_render(template=template, context=context, expected=expected)
 
 
-def test_for_tag_unpack05(assert_render):
-    template = "{% for num1, num2, num3, num4 in items %}{{ num1 }}{{ num2 }}{{ num3 }}{{ num4 }}/{% endfor %}"
+def test_for_tag_with_two_variable_names_without_whitespace(assert_render):
+    template = "{% for key,value in items %}{{ key }}:{{ value }}/{% endfor %}"
+    context = {"items": (("one", 1), ("two", 2))}
+    expected = "one:1/two:2/"
+    assert_render(template=template, context=context, expected=expected)
+
+
+def test_for_tag_with_more_variable_names_with_whitespace(assert_render):
+    template = "{% for num1 , num2 , num3 , num4 in items %}{{ num1 }}{{ num2 }}{{ num3 }}{{ num4 }}/{% endfor %}"
+    context = {"items": ((1, 2, 3, 4), (4, 5, 6, 7))}
+    expected = "1234/4567/"
+    assert_render(template=template, context=context, expected=expected)
+
+
+def test_for_tag_with_more_variable_names_without_whitespace(assert_render):
+    template = "{% for num1,num2,num3,num4 in items %}{{ num1 }}{{ num2 }}{{ num3 }}{{ num4 }}/{% endfor %}"
     context = {"items": ((1, 2, 3, 4), (4, 5, 6, 7))}
     expected = "1234/4567/"
     assert_render(template=template, context=context, expected=expected)

--- a/tests/tags/test_for.py
+++ b/tests/tags/test_for.py
@@ -834,12 +834,13 @@ def test_for_tag_unpack07(assert_parse_error):
         "'for' tag received an invalid argument: for key,,value in items"
     )
     rusty_message = snapshot("""\
-  × Unexpected expression in for loop:
+  × Unexpected comma in for loop:
    ╭────
  1 │ {% for key,,value in items %}{{ key }}:{{ value }}/{% endfor %}
    ·            ┬
-   ·            ╰── unexpected expression
+   ·            ╰── here
    ╰────
+  help: Try removing the comma, or adding a variable name before it
 """)
     assert_parse_error(
         template=template, django_message=django_message, rusty_message=rusty_message

--- a/tests/tags/test_for.py
+++ b/tests/tags/test_for.py
@@ -996,3 +996,57 @@ def test_for_tag_invalid_variable_names_02(assert_parse_error):
     assert_parse_error(
         template=template, django_message=django_message, rusty_message=rusty_message
     )
+
+
+def test_for_tag_invalid_variable_names_03(assert_parse_error):
+    template = "{% for key , @ value in items %}{{ key }}:{{ value }}/{% endfor %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for key , @ value in items"
+    )
+    rusty_message = snapshot("""\
+  × Invalid variable name @ in for loop:
+   ╭────
+ 1 │ {% for key , @ value in items %}{{ key }}:{{ value }}/{% endfor %}
+   ·              ┬
+   ·              ╰── invalid variable name
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_invalid_variable_names_04(assert_parse_error):
+    template = "{% for key , yiuyi value in items %}{{ key }}:{{ value }}/{% endfor %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for key , yiuyi value in items"
+    )
+    rusty_message = snapshot("""\
+  × Unexpected expression in for loop. Did you miss a comma when unpacking?
+   ╭────
+ 1 │ {% for key , yiuyi value in items %}{{ key }}:{{ value }}/{% endfor %}
+   ·                    ──┬──
+   ·                      ╰── unexpected expression
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_invalid_variable_names_05(assert_parse_error):
+    template = "{% for key , & value in items %}{{ key }}:{{ value }}/{% endfor %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for key , & value in items"
+    )
+    rusty_message = snapshot("""\
+  × Invalid variable name & in for loop:
+   ╭────
+ 1 │ {% for key , & value in items %}{{ key }}:{{ value }}/{% endfor %}
+   ·              ┬
+   ·              ╰── invalid variable name
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )

--- a/tests/tags/test_for.py
+++ b/tests/tags/test_for.py
@@ -846,6 +846,25 @@ def test_for_tag_unpack07(assert_parse_error):
     )
 
 
+def test_for_tag_unpack07_whitespace(assert_parse_error):
+    template = "{% for key , , value in items %}{{ key }}:{{ value }}/{% endfor %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for key , , value in items"
+    )
+    rusty_message = snapshot("""\
+  × Unexpected comma in for loop:
+   ╭────
+ 1 │ {% for key , , value in items %}{{ key }}:{{ value }}/{% endfor %}
+   ·              ┬
+   ·              ╰── here
+   ╰────
+  help: Try removing the comma, or adding a variable name before it
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
 def test_for_tag_unpack08(assert_parse_error):
     """
     This test were taken from django.
@@ -881,6 +900,61 @@ def test_for_tag_without_comma(assert_parse_error):
  1 │ {% for key value in items %}
    ·            ──┬──
    ·              ╰── unexpected expression
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_no_space_btw_comma_and_value(assert_parse_error):
+    template = "{% for ,value in items %}{{ value }}/{% endfor %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for ,value in items"
+    )
+    rusty_message = snapshot("""\
+  × Unexpected comma in for loop:
+   ╭────
+ 1 │ {% for ,value in items %}{{ value }}/{% endfor %}
+   ·        ┬
+   ·        ╰── here
+   ╰────
+  help: Try removing the comma, or adding a variable name before it
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_unexpected_token_in_loop(assert_parse_error):
+    template = "{% for key ; value in items %}{{ key }}:{{ value }}/{% endfor %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for key ; value in items"
+    )
+    rusty_message = snapshot("""\
+  × Unexpected expression in for loop. Did you miss a comma when unpacking?
+   ╭────
+ 1 │ {% for key ; value in items %}{{ key }}:{{ value }}/{% endfor %}
+   ·            ┬
+   ·            ╰── unexpected expression
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_unexpected_token_after_comma(assert_parse_error):
+    template = "{% for key , ; value in items %}{{ key }}:{{ value }}/{% endfor %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for key , ; value in items"
+    )
+    rusty_message = snapshot("""\
+  × Unexpected expression in for loop. Did you miss a comma when unpacking?
+   ╭────
+ 1 │ {% for key , ; value in items %}{{ key }}:{{ value }}/{% endfor %}
+   ·                ──┬──
+   ·                  ╰── unexpected expression
    ╰────
 """)
     assert_parse_error(

--- a/tests/tags/test_for.py
+++ b/tests/tags/test_for.py
@@ -823,3 +823,66 @@ def test_for_tag_with_more_variable_names_without_whitespace(assert_render):
     context = {"items": ((1, 2, 3, 4), (4, 5, 6, 7))}
     expected = "1234/4567/"
     assert_render(template=template, context=context, expected=expected)
+
+
+def test_for_tag_unpack07(assert_parse_error):
+    """
+    This test were taken from django.
+    """
+    template = "{% for key,,value in items %}{{ key }}:{{ value }}/{% endfor %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for key,,value in items"
+    )
+    rusty_message = snapshot("""\
+  × Unexpected expression in for loop:
+   ╭────
+ 1 │ {% for key,,value in items %}{{ key }}:{{ value }}/{% endfor %}
+   ·            ┬
+   ·            ╰── unexpected expression
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_unpack08(assert_parse_error):
+    """
+    This test were taken from django.
+    """
+    template = "{% for key,value, in items %}{{ key }}:{{ value }}/{% endfor %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for key,value, in items"
+    )
+    rusty_message = snapshot("""\
+  × Expected another variable when unpacking in for loop:
+   ╭────
+ 1 │ {% for key,value, in items %}{{ key }}:{{ value }}/{% endfor %}
+   ·            ──┬──
+   ·              ╰── after this variable
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
+
+
+def test_for_tag_without_comma(assert_parse_error):
+    """
+    This test were taken from django ie. test_for_tag_unpack06
+    """
+    template = "{% for key value in items %}"
+    django_message = snapshot(
+        "'for' tag received an invalid argument: for key value in items"
+    )
+    rusty_message = snapshot("""\
+  × Unexpected expression in for loop. Did you miss a comma when unpacking?
+   ╭────
+ 1 │ {% for key value in items %}
+   ·            ──┬──
+   ·              ╰── unexpected expression
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )

--- a/tests/tags/test_for.py
+++ b/tests/tags/test_for.py
@@ -795,3 +795,17 @@ def test_missing_argument_after_for_loop(assert_render_error):
         django_message=django_message,
         rusty_message=rusty_message,
     )
+
+
+def test_for_tag_unpack04(assert_render):
+    template = "{% for key , value in items %}{{ key }}:{{ value }}/{% endfor %}"
+    context = {"items": (("one", 1), ("two", 2))}
+    expected = "one:1/two:2/"
+    assert_render(template=template, context=context, expected=expected)
+
+
+def test_for_tag_unpack05(assert_render):
+    template = "{% for num1, num2, num3, num4 in items %}{{ num1 }}{{ num2 }}{{ num3 }}{{ num4 }}/{% endfor %}"
+    context = {"items": ((1, 2, 3, 4), (4, 5, 6, 7))}
+    expected = "1234/4567/"
+    assert_render(template=template, context=context, expected=expected)


### PR DESCRIPTION
Fixes #396 
- We were seperating the variable names using whitespace inside the `lex_variable_name`. So when we used something like ` key , value in items` , we only get `key` as variable names and when it reaches to `lex_in()` it have `, value in items` in it,  so it raises error their.