### PR TITLE
Update `CONTRIBUTING.md` to document `ModuleNotFoundError` and translations failing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,15 @@ Note: The `[dev]` dependency group is defined in `pyproject.toml` and includes a
 
 ## Running tests
 
+### Python tests with pytest
 To run the Python tests, build Django Rusty Templates in develop mode with maturin and then run pytest.
 Each change in rust needs a new execution of maturin develop.
-
 ```bash
 $ maturin develop
 $ pytest
 ```
+
+If translation tests are failing, make sure that you have compiled django translations by running `django-admin compilemessages` in `tests/` directory.
 
 ### Rust tests with cargo
 You can also run the Rust tests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ If you get an `ImportError` from python, you may need to set the `PYTHONPATH` en
 export PYTHONPATH=/path/to/venv/lib/python3.x/site-packages
 ```
 
-You might also get a `ModuleNotFoundError("No module named 'tests.settings'")`, you may also add the project root directory to the `PYTHON_PATH` environment variable:
+If you get a `ModuleNotFoundError("No module named 'tests.settings'")`, you can work around the issue by adding the project root directory to the `PYTHON_PATH` environment variable:
 ```bash
 export PYTHONPATH="/path/to/django-rusty-templates:/path/to/venv/lib/python3.x/site-packages"
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ $ maturin develop
 $ pytest
 ```
 
+### Rust tests with cargo
 You can also run the Rust tests:
 
 ```bash
@@ -52,6 +53,11 @@ If you get an `ImportError` from python, you may need to set the `PYTHONPATH` en
 
 ```bash
 export PYTHONPATH=/path/to/venv/lib/python3.x/site-packages
+```
+
+You might also get a `ModuleNotFoundError("No module named 'tests.settings'")`, you may also add the project root directory to the `PYTHON_PATH` environment variable:
+```bash
+export PYTHONPATH="/path/to/django-rusty-templates:/path/to/venv/lib/python3.x/site-packages"
 ```
 
 ## Pre-commit hooks


### PR DESCRIPTION
Hi everyone!

I've stumbled upon some errors during the setup of the repo for running tests.

## `pytest` failing for translations
### Issue
```bash
$ pytest tests/test_translation.py
FAILED tests/test_translation.py::test_translate_valid - AssertionError: assert 'Welcome\n\nGoodbye\n\n' == 'Willkommen\n...edersehen\n\n'
```

Django needs to have `.mo` files to be compiled for translations to work.

### Suggested solution
Run `django-admin compilemessages` in `tests/` to compile translations.
Added this section to the `CONTRIBUTING.md` docs.


## `ModuleNotFoundError` when running `cargo test --workspace`
### Issue
Running on macos Tahoe
```
$ uv --version
uv 0.11.3 (Homebrew 2026-04-01 aarch64-apple-darwin)
$ python --version
Python 3.14.3
```

```
$ PYTHONPATH="path/to/venv/lib/python3.x/site-packages" cargo test --workspace
---- loaders::tests::test_get_app_template_dirs stdout ----

thread 'loaders::tests::test_get_app_template_dirs' (71687586) panicked at src/loaders.rs:283:45:
called `Result::unwrap()` on an `Err` value: PyErr { type: <class 'ModuleNotFoundError'>, value: ModuleNotFoundError("No module named 'tests.settings'"), traceback: Some("Traceback (most recent call last):\n  File \"/Users/mariusmenault/dev/django-rusty-templates/.venv2/lib/python3.14/site-packages/django/__init__.py\", line 19, in setup\n    configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)\n  File \"/Users/mariusmenault/dev/django-rusty-templates/.venv2/lib/python3.14/site-packages/django/conf/__init__.py\", line 81, in __getattr__\n    self._setup(name)\n  File \"/Users/mariusmenault/dev/django-rusty-templates/.venv2/lib/python3.14/site-packages/django/conf/__init__.py\", line 68, in _setup\n    self._wrapped = Settings(settings_module)\n  File \"/Users/mariusmenault/dev/django-rusty-templates/.venv2/lib/python3.14/site-packages/django/conf/__init__.py\", line 166, in __init__\n    mod = importlib.import_module(self.SETTINGS_MODULE)\n  File \"/opt/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/importlib/__init__.py\", line 88, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File \"<frozen importlib._bootstrap>\", line 1398, in _gcd_import\n  File \"<frozen importlib._bootstrap>\", line 1371, in _find_and_load\n  File \"<frozen importlib._bootstrap>\", line 1335, in _find_and_load_unlocked\n") 
```

### Suggested solution
Add the root directory to `PYTHONPATH` env for `tests.settings` to be discovered by `PyO3` and be added to `sys.path`.
It happened with `uv` venv activated, on macos.
Added this section to the `CONTRIBUTING.md` docs.


Hope it could help others to start contributing!

Also, maybe we could include those test running commands in the `Justfile`?