### PR TITLE
Add `force_escape` filter

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -19,6 +19,7 @@ pub enum FilterType {
     Escape(EscapeFilter),
     Escapejs(EscapejsFilter),
     External(ExternalFilter),
+    ForceEscape(ForceEscapeFilter),
     Last(LastFilter),
     Lower(LowerFilter),
     Length(LengthFilter),
@@ -146,6 +147,9 @@ impl LastFilter {
         Self { at }
     }
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ForceEscapeFilter;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LowerFilter;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -25,6 +25,7 @@ use crate::filters::EscapeFilter;
 use crate::filters::EscapejsFilter;
 use crate::filters::ExternalFilter;
 use crate::filters::FilterType;
+use crate::filters::ForceEscapeFilter;
 use crate::filters::LastFilter;
 use crate::filters::LengthFilter;
 use crate::filters::LowerFilter;
@@ -202,6 +203,10 @@ impl Filter {
             "escapejs" => match right {
                 Some(right) => return Err(unexpected_argument("escapejs", right)),
                 None => FilterType::Escapejs(EscapejsFilter),
+            },
+            "force_escape" => match right {
+                Some(right) => return Err(unexpected_argument("force_escape", right)),
+                None => FilterType::ForceEscape(ForceEscapeFilter),
             },
             "last" => match right {
                 Some(right) => return Err(unexpected_argument("last", right)),

--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -497,6 +497,13 @@ impl ResolveFilter for ForceEscapeFilter {
         template: TemplateString<'t>,
         context: &mut Context,
     ) -> ResolveResult<'t, 'py> {
+        let variable = match variable {
+            // We want to re-run the escape filter even if the content has already been resolved to safe HTML
+            Some(Content::String(ContentString::HtmlSafe(c))) => {
+                Some(Content::String(ContentString::String(c)))
+            }
+            other => other,
+        };
         EscapeFilter.resolve(variable, py, template, context)
     }
 }

--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -217,10 +217,10 @@ impl ResolveFilter for CutFilter {
         let result = match content_string {
             ContentString::String(s) => ContentString::String(cut(s, &arg).into()),
             ContentString::HtmlSafe(s) => {
-                let cut = cut(s, &arg);
+                let cut = cut(s, &arg).into();
                 match arg.as_ref() {
-                    ";" => ContentString::HtmlUnsafe(cut.into()),
-                    _ => ContentString::HtmlSafe(cut.into()),
+                    ";" => ContentString::HtmlUnsafe(cut),
+                    _ => ContentString::HtmlSafe(cut),
                 }
             }
             ContentString::HtmlUnsafe(s) => ContentString::HtmlUnsafe(cut(s, &arg).into()),

--- a/src/render/filters.rs
+++ b/src/render/filters.rs
@@ -11,8 +11,9 @@ use crate::error::{AnnotatePyErr, PyRenderError, RenderError};
 use crate::filters::{
     AddFilter, AddSlashesFilter, CapfirstFilter, CenterFilter, CutFilter, DateFilter,
     DefaultFilter, DefaultIfNoneFilter, DivisibleByFilter, EscapeFilter, EscapejsFilter,
-    ExternalFilter, FilterType, LastFilter, LengthFilter, LowerFilter, SafeFilter, SlugifyFilter,
-    TitleFilter, UpperFilter, WordcountFilter, WordwrapFilter, YesnoFilter,
+    ExternalFilter, FilterType, ForceEscapeFilter, LastFilter, LengthFilter, LowerFilter,
+    SafeFilter, SlugifyFilter, TitleFilter, UpperFilter, WordcountFilter, WordwrapFilter,
+    YesnoFilter,
 };
 use crate::parse::Filter;
 use crate::render::common::gettext;
@@ -47,6 +48,7 @@ impl Resolve for Filter {
             FilterType::Escape(filter) => filter.resolve(left, py, template, context),
             FilterType::Escapejs(filter) => filter.resolve(left, py, template, context),
             FilterType::External(filter) => filter.resolve(left, py, template, context),
+            FilterType::ForceEscape(filter) => filter.resolve(left, py, template, context),
             FilterType::Last(filter) => filter.resolve(left, py, template, context),
             FilterType::Lower(filter) => filter.resolve(left, py, template, context),
             FilterType::Length(filter) => filter.resolve(left, py, template, context),
@@ -484,6 +486,18 @@ impl ResolveFilter for ExternalFilter {
             None => filter.call1((variable,))?,
         };
         Ok(Some(Content::Py(value)))
+    }
+}
+
+impl ResolveFilter for ForceEscapeFilter {
+    fn resolve<'t, 'py>(
+        &self,
+        variable: Option<Content<'t, 'py>>,
+        py: Python<'py>,
+        template: TemplateString<'t>,
+        context: &mut Context,
+    ) -> ResolveResult<'t, 'py> {
+        EscapeFilter.resolve(variable, py, template, context)
     }
 }
 

--- a/src/render/types.rs
+++ b/src/render/types.rs
@@ -471,10 +471,10 @@ impl<'t, 'py> Content<'t, 'py> {
         let output = match self {
             Self::Py(content) => resolve_python(content, context)?,
             Self::String(content) => content,
-            Self::Float(content) => ContentString::String(content.to_string().into()),
-            Self::Int(content) => ContentString::String(content.to_string().into()),
-            Self::Bool(true) => ContentString::String(Cow::Borrowed("True")),
-            Self::Bool(false) => ContentString::String(Cow::Borrowed("False")),
+            Self::Float(content) => return Ok(content.to_string().into()),
+            Self::Int(content) => return Ok(content.to_string().into()),
+            Self::Bool(true) => return Ok(Cow::Borrowed("True")),
+            Self::Bool(false) => return Ok(Cow::Borrowed("False")),
         };
         Ok(render_value_in_context(output, context))
     }

--- a/src/render/types.rs
+++ b/src/render/types.rs
@@ -456,16 +456,27 @@ pub enum Content<'t, 'py> {
     Bool(bool),
 }
 
+fn render_value_in_context<'t>(value: ContentString<'t>, context: &Context) -> Cow<'t, str> {
+    match value {
+        ContentString::String(content) | ContentString::HtmlSafe(content) => content,
+        ContentString::HtmlUnsafe(content) => match context.autoescape {
+            true => Cow::Owned(encode_quoted_attribute(&content).to_string()),
+            false => Cow::Owned(content.into()),
+        },
+    }
+}
+
 impl<'t, 'py> Content<'t, 'py> {
     pub fn render(self, context: &Context) -> PyResult<Cow<'t, str>> {
-        Ok(match self {
-            Self::Py(content) => resolve_python(content, context)?.content(),
-            Self::String(content) => content.content(),
-            Self::Float(content) => content.to_string().into(),
-            Self::Int(content) => content.to_string().into(),
-            Self::Bool(true) => "True".into(),
-            Self::Bool(false) => "False".into(),
-        })
+        let output = match self {
+            Self::Py(content) => resolve_python(content, context)?,
+            Self::String(content) => content,
+            Self::Float(content) => ContentString::String(content.to_string().into()),
+            Self::Int(content) => ContentString::String(content.to_string().into()),
+            Self::Bool(true) => ContentString::String(Cow::Borrowed("True")),
+            Self::Bool(false) => ContentString::String(Cow::Borrowed("False")),
+        };
+        Ok(render_value_in_context(output, context))
     }
 
     pub fn resolve_string(self, context: &Context) -> PyResult<ContentString<'t>> {

--- a/tests/filters/test_escape.py
+++ b/tests/filters/test_escape.py
@@ -68,12 +68,11 @@ def test_escape_autoescape_off_lower(assert_render):
 def test_autoescape_on_with_escape_does_nothing(template_engine):
     template_without_escape = "{% autoescape on %}{{ html }}{% endautoescape %}"
     template_with_escape = "{% autoescape on %}{{ html|escape }}{% endautoescape %}"
-    html = "<p>Hello World!</p>"
-    context = {"html": html}
+    context = {"html": "<p>Hello World!</p>"}
     rendered_without_escape = template_engine.from_string(
         template_without_escape
-    ).render(context, None)
+    ).render(context)
     rendered_with_escape = template_engine.from_string(template_with_escape).render(
-        context, None
+        context
     )
     assert rendered_without_escape == rendered_with_escape

--- a/tests/filters/test_escape.py
+++ b/tests/filters/test_escape.py
@@ -63,3 +63,17 @@ def test_escape_autoescape_off_lower(assert_render):
     html = "<p>Hello World!</p>"
     escaped = "&lt;p&gt;hello world!&lt;/p&gt;"
     assert_render(template=template, context={"html": html}, expected=escaped)
+
+
+def test_autoescape_on_with_escape_does_nothing(template_engine):
+    template_without_escape = "{% autoescape on %}{{ html }}{% endautoescape %}"
+    template_with_escape = "{% autoescape on %}{{ html|escape }}{% endautoescape %}"
+    html = "<p>Hello World!</p>"
+    context = {"html": html}
+    rendered_without_escape = template_engine.from_string(
+        template_without_escape
+    ).render(context, None)
+    rendered_with_escape = template_engine.from_string(template_with_escape).render(
+        context, None
+    )
+    assert rendered_without_escape == rendered_with_escape

--- a/tests/filters/test_force_escape.py
+++ b/tests/filters/test_force_escape.py
@@ -1,97 +1,4 @@
-# TODO: REMOVE ME - There are the tests from `django` already existing for `force_escape` filter, I've put them here to port them one by one
-
-# from django.template.defaultfilters import force_escape
-# from django.test import SimpleTestCase
-# from django.utils.safestring import SafeData
-#
-# from ..utils import setup
-#
-#
-# class ForceEscapeTests(SimpleTestCase):
-#     """
-#     Force_escape is applied immediately. It can be used to provide
-#     double-escaping, for example.
-#     """
-#
-#     @setup(
-#         {
-#             "force-escape01": (
-#                 "{% autoescape off %}{{ a|force_escape }}{% endautoescape %}"
-#             )
-#         }
-#     )
-#     def test_force_escape01(self):
-#         output = self.engine.render_to_string("force-escape01", {"a": "x&y"})
-#         self.assertEqual(output, "x&amp;y")
-#
-#     @setup({"force-escape02": "{{ a|force_escape }}"})
-#     def test_force_escape02(self):
-#         output = self.engine.render_to_string("force-escape02", {"a": "x&y"})
-#         self.assertEqual(output, "x&amp;y")
-#
-#     @setup(
-#         {
-#             "force-escape03": (
-#                 "{% autoescape off %}{{ a|force_escape|force_escape }}"
-#                 "{% endautoescape %}"
-#             )
-#         }
-#     )
-#     def test_force_escape03(self):
-#         output = self.engine.render_to_string("force-escape03", {"a": "x&y"})
-#         self.assertEqual(output, "x&amp;amp;y")
-#
-#     @setup({"force-escape04": "{{ a|force_escape|force_escape }}"})
-#     def test_force_escape04(self):
-#         output = self.engine.render_to_string("force-escape04", {"a": "x&y"})
-#         self.assertEqual(output, "x&amp;amp;y")
-#
-#     # Because the result of force_escape is "safe", an additional
-#     # escape filter has no effect.
-#     @setup(
-#         {
-#             "force-escape05": (
-#                 "{% autoescape off %}{{ a|force_escape|escape }}{% endautoescape %}"
-#             )
-#         }
-#     )
-#     def test_force_escape05(self):
-#         output = self.engine.render_to_string("force-escape05", {"a": "x&y"})
-#         self.assertEqual(output, "x&amp;y")
-#
-#     @setup({"force-escape06": "{{ a|force_escape|escape }}"})
-#     def test_force_escape06(self):
-#         output = self.engine.render_to_string("force-escape06", {"a": "x&y"})
-#         self.assertEqual(output, "x&amp;y")
-#
-#     @setup(
-#         {
-#             "force-escape07": (
-#                 "{% autoescape off %}{{ a|escape|force_escape }}{% endautoescape %}"
-#             )
-#         }
-#     )
-#     def test_force_escape07(self):
-#         output = self.engine.render_to_string("force-escape07", {"a": "x&y"})
-#         self.assertEqual(output, "x&amp;amp;y")
-#
-#     @setup({"force-escape08": "{{ a|escape|force_escape }}"})
-#     def test_force_escape08(self):
-#         output = self.engine.render_to_string("force-escape08", {"a": "x&y"})
-#         self.assertEqual(output, "x&amp;amp;y")
-#
-#
-# class FunctionTests(SimpleTestCase):
-#     def test_escape(self):
-#         escaped = force_escape("<some html & special characters > here")
-#         self.assertEqual(escaped, "&lt;some html &amp; special characters &gt; here")
-#         self.assertIsInstance(escaped, SafeData)
-#
-#     def test_unicode(self):
-#         self.assertEqual(
-#             force_escape("<some html & special characters > here ĐÅ€£"),
-#             "&lt;some html &amp; special characters &gt; here \u0110\xc5\u20ac\xa3",
-#         )
+from inline_snapshot import snapshot
 
 
 def test_force_escape(assert_render):
@@ -99,6 +6,28 @@ def test_force_escape(assert_render):
     a = "x&y"
     escaped = "x&amp;y"
     assert_render(template=template, context={"a": a}, expected=escaped)
+
+
+def test_force_escape_missing_value(assert_render):
+    template = "{{ value|force_escape }}"
+    context = {}
+    assert_render(template, context, "")
+
+
+def test_force_escape_with_argument(assert_parse_error):
+    template = "{{ value|force_escape:invalid }}"
+    django_message = snapshot("force_escape requires 1 arguments, 2 provided")
+    rusty_message = snapshot("""\
+  × force_escape filter does not take an argument
+   ╭────
+ 1 │ {{ value|force_escape:invalid }}
+   ·                       ───┬───
+   ·                          ╰── unexpected argument
+   ╰────
+""")
+    assert_parse_error(
+        template=template, django_message=django_message, rusty_message=rusty_message
+    )
 
 
 def test_force_escape_in_autoescape_off(assert_render):
@@ -116,9 +45,44 @@ def test_force_escape_in_autoescape_on(assert_render):
 
 
 def test_chaining_force_escape(assert_render):
+    template = "{{ a|force_escape|force_escape }}"
+    a = "x&y"
+    escaped = "x&amp;amp;y"
+    assert_render(template=template, context={"a": a}, expected=escaped)
+
+
+def test_chaining_force_escape_in_autoescape_off(assert_render):
     template = (
         "{% autoescape off %}{{ a|force_escape|force_escape }}{% endautoescape %}"
     )
+    a = "x&y"
+    escaped = "x&amp;amp;y"
+    assert_render(template=template, context={"a": a}, expected=escaped)
+
+
+def test_escape_after_force_escape_is_noop(assert_render):
+    template = "{{ a|force_escape|escape }}"
+    a = "x&y"
+    escaped = "x&amp;y"
+    assert_render(template=template, context={"a": a}, expected=escaped)
+
+
+def test_escape_after_force_escape_in_autoescape_off_is_noop(assert_render):
+    template = "{% autoescape off %}{{ a|force_escape|escape }}{% endautoescape %}"
+    a = "x&y"
+    escaped = "x&amp;y"
+    assert_render(template=template, context={"a": a}, expected=escaped)
+
+
+def test_force_escape_after_escape(assert_render):
+    template = "{{ a|escape|force_escape }}"
+    a = "x&y"
+    escaped = "x&amp;amp;y"
+    assert_render(template=template, context={"a": a}, expected=escaped)
+
+
+def test_force_escape_after_escape_in_autoescape_off(assert_render):
+    template = "{% autoescape off %}{{ a|escape|force_escape }}{% endautoescape %}"
     a = "x&y"
     escaped = "x&amp;amp;y"
     assert_render(template=template, context={"a": a}, expected=escaped)

--- a/tests/filters/test_force_escape.py
+++ b/tests/filters/test_force_escape.py
@@ -86,3 +86,17 @@ def test_force_escape_after_escape_in_autoescape_off(assert_render):
     a = "x&y"
     escaped = "x&amp;amp;y"
     assert_render(template=template, context={"a": a}, expected=escaped)
+
+
+def test_chaining(assert_render):
+    template = '{{ a|force_escape|cut:";" }}'
+    a = "a < b"
+    escaped = "a &amp;lt b"
+    assert_render(template=template, context={"a": a}, expected=escaped)
+
+
+def test_chaining_in_autoescape_off(assert_render):
+    template = '{% autoescape off %}{{ a|force_escape|cut:";" }}{% endautoescape %}'
+    a = "a < b"
+    escaped = "a &lt b"
+    assert_render(template=template, context={"a": a}, expected=escaped)

--- a/tests/filters/test_force_escape.py
+++ b/tests/filters/test_force_escape.py
@@ -1,0 +1,124 @@
+# TODO: REMOVE ME - There are the tests from `django` already existing for `force_escape` filter, I've put them here to port them one by one
+
+# from django.template.defaultfilters import force_escape
+# from django.test import SimpleTestCase
+# from django.utils.safestring import SafeData
+#
+# from ..utils import setup
+#
+#
+# class ForceEscapeTests(SimpleTestCase):
+#     """
+#     Force_escape is applied immediately. It can be used to provide
+#     double-escaping, for example.
+#     """
+#
+#     @setup(
+#         {
+#             "force-escape01": (
+#                 "{% autoescape off %}{{ a|force_escape }}{% endautoescape %}"
+#             )
+#         }
+#     )
+#     def test_force_escape01(self):
+#         output = self.engine.render_to_string("force-escape01", {"a": "x&y"})
+#         self.assertEqual(output, "x&amp;y")
+#
+#     @setup({"force-escape02": "{{ a|force_escape }}"})
+#     def test_force_escape02(self):
+#         output = self.engine.render_to_string("force-escape02", {"a": "x&y"})
+#         self.assertEqual(output, "x&amp;y")
+#
+#     @setup(
+#         {
+#             "force-escape03": (
+#                 "{% autoescape off %}{{ a|force_escape|force_escape }}"
+#                 "{% endautoescape %}"
+#             )
+#         }
+#     )
+#     def test_force_escape03(self):
+#         output = self.engine.render_to_string("force-escape03", {"a": "x&y"})
+#         self.assertEqual(output, "x&amp;amp;y")
+#
+#     @setup({"force-escape04": "{{ a|force_escape|force_escape }}"})
+#     def test_force_escape04(self):
+#         output = self.engine.render_to_string("force-escape04", {"a": "x&y"})
+#         self.assertEqual(output, "x&amp;amp;y")
+#
+#     # Because the result of force_escape is "safe", an additional
+#     # escape filter has no effect.
+#     @setup(
+#         {
+#             "force-escape05": (
+#                 "{% autoescape off %}{{ a|force_escape|escape }}{% endautoescape %}"
+#             )
+#         }
+#     )
+#     def test_force_escape05(self):
+#         output = self.engine.render_to_string("force-escape05", {"a": "x&y"})
+#         self.assertEqual(output, "x&amp;y")
+#
+#     @setup({"force-escape06": "{{ a|force_escape|escape }}"})
+#     def test_force_escape06(self):
+#         output = self.engine.render_to_string("force-escape06", {"a": "x&y"})
+#         self.assertEqual(output, "x&amp;y")
+#
+#     @setup(
+#         {
+#             "force-escape07": (
+#                 "{% autoescape off %}{{ a|escape|force_escape }}{% endautoescape %}"
+#             )
+#         }
+#     )
+#     def test_force_escape07(self):
+#         output = self.engine.render_to_string("force-escape07", {"a": "x&y"})
+#         self.assertEqual(output, "x&amp;amp;y")
+#
+#     @setup({"force-escape08": "{{ a|escape|force_escape }}"})
+#     def test_force_escape08(self):
+#         output = self.engine.render_to_string("force-escape08", {"a": "x&y"})
+#         self.assertEqual(output, "x&amp;amp;y")
+#
+#
+# class FunctionTests(SimpleTestCase):
+#     def test_escape(self):
+#         escaped = force_escape("<some html & special characters > here")
+#         self.assertEqual(escaped, "&lt;some html &amp; special characters &gt; here")
+#         self.assertIsInstance(escaped, SafeData)
+#
+#     def test_unicode(self):
+#         self.assertEqual(
+#             force_escape("<some html & special characters > here ĐÅ€£"),
+#             "&lt;some html &amp; special characters &gt; here \u0110\xc5\u20ac\xa3",
+#         )
+
+
+def test_force_escape(assert_render):
+    template = "{{ a|force_escape }}"
+    a = "x&y"
+    escaped = "x&amp;y"
+    assert_render(template=template, context={"a": a}, expected=escaped)
+
+
+def test_force_escape_in_autoescape_off(assert_render):
+    template = "{% autoescape off %}{{ a|force_escape }}{% endautoescape %}"
+    a = "x&y"
+    escaped = "x&amp;y"
+    assert_render(template=template, context={"a": a}, expected=escaped)
+
+
+def test_force_escape_in_autoescape_on(assert_render):
+    template = "{% autoescape on %}{{ a|force_escape }}{% endautoescape %}"
+    a = "x&y"
+    escaped = "x&amp;y"
+    assert_render(template=template, context={"a": a}, expected=escaped)
+
+
+def test_chaining_force_escape(assert_render):
+    template = (
+        "{% autoescape off %}{{ a|force_escape|force_escape }}{% endautoescape %}"
+    )
+    a = "x&y"
+    escaped = "x&amp;amp;y"
+    assert_render(template=template, context={"a": a}, expected=escaped)


### PR DESCRIPTION
Adds the `force_escape` template filter (see https://github.com/LilyFirefly/django-rusty-templates/issues/1) support by forcing the call to `EscapeFilter.resolve()` even if the content is already `ContentString::HtmlSave`.

The python tests are willingly repetitive to follow Django tests definition. I found using a small wrapper function for `autoescape off` block not really useful in this case.

Let me know what you think !