### PR TITLE
Improve `justfile`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,12 @@
 ## Getting started with development
 
-django-rusty-templates is written in Rust, so you'll need to install the
-[Rust toolchain](https://www.rust-lang.org/tools/install).
+### Requirements
+`django-rusty-templates` is written in Rust, so you'll need to install the [Rust toolchain](https://www.rust-lang.org/tools/install).
 
-### Option 1: Using uv
+To run the `just` recipes, you will need to have [Just](https://github.com/casey/just) installed.
+
+### Python dependencies
+#### Option 1: Using uv
 
 [uv](https://docs.astral.sh/uv/) is a fast Python package installer and resolver. Using it will significantly speed up dependency installation.
 
@@ -20,7 +23,7 @@ $ uv sync
 $ source .venv/bin/activate
 ```
 
-### Option 2: Using standard Python tools
+#### Option 2: Using standard Python tools
 
 If you prefer not to use uv, you can set up your development environment with standard Python tools:
 
@@ -32,6 +35,9 @@ $ pip install --group dev
 
 Note: The `[dev]` dependency group is defined in `pyproject.toml` and includes all necessary development dependencies.
 
+### Final step
+Run `just bootstrap`.
+
 ## Running tests
 
 ### Python tests with pytest
@@ -42,7 +48,7 @@ $ maturin develop
 $ pytest
 ```
 
-If translation tests are failing, make sure that you have compiled django translations by running `django-admin compilemessages` in `tests/` directory.
+Or you can run `just python-test`
 
 ### Rust tests with cargo
 You can also run the Rust tests:
@@ -80,5 +86,3 @@ $ just python-coverage
 $ just rust-coverage
 $ just rust-coverage-browser
 ```
-
-You will need [Just](https://github.com/casey/just) installed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,9 @@ $ pip install --group dev
 Note: The `[dev]` dependency group is defined in `pyproject.toml` and includes all necessary development dependencies.
 
 ### Final step
-Run `just bootstrap`.
+**Compile translations**: run `django-admin compilemessages` in `tests/` directory
+
+Running `just bootstrap` does it for you.
 
 ## Running tests
 
@@ -48,7 +50,7 @@ $ maturin develop
 $ pytest
 ```
 
-Or you can run `just python-test`
+Running `just python-test` combines these two commands for you.
 
 ### Rust tests with cargo
 You can also run the Rust tests:

--- a/justfile
+++ b/justfile
@@ -3,6 +3,12 @@ set shell := ["bash", "-euox", "pipefail", "-c"]
 _default:
     @just --list --unsorted
 
+bootstrap:
+    #!/usr/bin/env bash
+    set -euox pipefail
+    # Compile translations
+    cd tests && django-admin compilemessages
+
 python-test *ARGS:
     maturin develop
     pytest {{ARGS}}

--- a/justfile
+++ b/justfile
@@ -1,3 +1,7 @@
+python-test *ARGS:
+    maturin develop
+    pytest {{ARGS}}
+
 python-coverage:
     maturin develop
     pytest --cov

--- a/justfile
+++ b/justfile
@@ -1,22 +1,30 @@
 set shell := ["bash", "-euox", "pipefail", "-c"]
 
+# List available recipes
 _default:
     @just --list --unsorted
 
+# Bootstrap the environment for running the test suite
 bootstrap:
     #!/usr/bin/env bash
     set -euox pipefail
     # Compile translations
     cd tests && django-admin compilemessages
 
+# Build the Rust extension and run the Python test suite (extra args forwarded to pytest)
+[group('test')]
 python-test *ARGS:
     maturin develop
     pytest {{ARGS}}
 
+# Run the Python test suite under coverage
+[group('coverage')]
 python-coverage:
     maturin develop
     pytest --cov
 
+# Print a terminal Rust coverage report from the Python test suite
+[group('coverage')]
 rust-coverage:
     #!/usr/bin/env bash
     set -euox pipefail
@@ -27,6 +35,8 @@ rust-coverage:
     pytest
     cargo llvm-cov report
 
+# Generate an HTML Rust coverage report and open it in the browser
+[group('coverage')]
 rust-coverage-browser:
     #!/usr/bin/env bash
     set -euox pipefail

--- a/justfile
+++ b/justfile
@@ -1,3 +1,8 @@
+set shell := ["bash", "-euox", "pipefail", "-c"]
+
+_default:
+    @just --list --unsorted
+
 python-test *ARGS:
     maturin develop
     pytest {{ARGS}}
@@ -7,7 +12,8 @@ python-coverage:
     pytest --cov
 
 rust-coverage:
-    #!/usr/bin/bash
+    #!/usr/bin/env bash
+    set -euox pipefail
     cargo llvm-cov clean --workspace
     source <(cargo llvm-cov show-env --sh)
     cargo llvm-cov --no-report
@@ -16,7 +22,8 @@ rust-coverage:
     cargo llvm-cov report
 
 rust-coverage-browser:
-    #!/usr/bin/bash
+    #!/usr/bin/env bash
+    set -euox pipefail
     cargo llvm-cov clean --workspace
     source <(cargo llvm-cov show-env --sh)
     cargo llvm-cov --no-report


### PR DESCRIPTION
Added some *nice to have* recipes and features to the justfile to facilitate onboarding and compatibility.

- [x] `bootstrap` recipe: includes the `compilemessages` command, as referenced in the `CONTRIBUTING.md` guide.
- [x] list behaviour on `just` empty call
- [x] `python-test` to run `maturin` then `pytest` 
- [x] `set -euox pipefail` as recommended in the [official docs](official docs)
- [x] `/usr/bin/env bash` instead of `/usr/bin/bash` in scripts

These are just suggestions, please add some others if you find them useful!