### PR TITLE
Bump rust version to 1.95.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 
 [workspace.dependencies]
 miette = { version = "7.6.0", features = ["fancy"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.95.0"
 profile = "minimal"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Should we wait for some cooling time ?

ref: https://releases.rs/docs/1.95.0/