### PR TITLE
Bump rust 1.98

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.98"
 
 [workspace.dependencies]
 miette = { version = "7.6.0", features = ["fancy"] }


### PR DESCRIPTION
may be followup from https://github.com/LilyFirefly/django-rusty-templates/pull/490